### PR TITLE
Added typings module resolution for screeps.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "screeps-typescript-declarations",
   "version": "2.0.0",
   "description": "Typescript declarations for Screeps API. To enable autocomplete and help with compilation",
+  "typings": "./dist/screeps.d.ts",
   "scripts": {
     "compile": "node_modules/.bin/tsc"
   },


### PR DESCRIPTION
With this commit, it should be a lot easier to install the definitions via the `typings` command.

Sources:
- http://www.typescriptlang.org/docs/handbook/typings-for-npm-packages.html
- https://github.com/typings/typings
