### PR TITLE
more StoreDefinition fixes

### DIFF
--- a/src/creep.ts
+++ b/src/creep.ts
@@ -16,7 +16,7 @@ declare class Creep extends RoomObject{
      * energy: number
      * The current amount of energy the creep is carrying.
      */
-    carry: { [resource: string]: number };
+    carry: StoreDefinition;
     /**
      * The total amount of resources the creep can carry.
      */

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -41,7 +41,8 @@ interface ReservationDefinition {
 }
 interface StoreDefinition {
     [resource: string]: number;
-    energy: number;
+    energy?: number;
+    power?: number;
 }
 
 interface LookAtResultWithPos {


### PR DESCRIPTION
make `energy` optional
add `power` back
change `creep.carry` to `StoreDefinition`
