### PR TITLE
Find path opts fixes

### DIFF
--- a/src/creep.ts
+++ b/src/creep.ts
@@ -131,13 +131,13 @@ declare class Creep extends RoomObject{
      * @param y Y position of the target in the room.
      * @param opts An object containing pathfinding options flags (see Room.findPath for more info) or one of the following: reusePath, serializeMemory, noPathFinding
      */
-    moveTo(x: number, y: number, opts?: MoveToOpts | PathFinderOps): number;
+    moveTo(x: number, y: number, opts?: MoveToOpts & FindPathOpts): number;
     /**
      * Find the optimal path to the target within the same room and move to it. A shorthand to consequent calls of pos.findPathTo() and move() methods. If the target is in another room, then the corresponding exit will be used as a target. Needs the MOVE body part.
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
      * @param opts An object containing pathfinding options flags (see Room.findPath for more info) or one of the following: reusePath, serializeMemory, noPathFinding
      */
-    moveTo(target: RoomPosition|{pos: RoomPosition}, opts?: MoveToOpts | PathFinderOps): number;
+    moveTo(target: RoomPosition|{pos: RoomPosition}, opts?: MoveToOpts & FindPathOpts): number;
     /**
      * Toggle auto notification when the creep is under attack. The notification will be sent to your account email. Turned on by default.
      * @param enabled Whether to enable notification or disable.

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -71,19 +71,90 @@ interface LookAtResultMatrix {
 }
 
 interface FindPathOpts {
+    /**
+     * Treat squares with creeps as walkable. Can be useful with too many moving creeps around or in some other cases. The default 
+     * value is false.
+     */
     ignoreCreeps?: boolean;
+
+    /**
+     * Treat squares with destructible structures (constructed walls, ramparts, spawns, extensions) as walkable. Use this flag when
+     * you need to move through a territory blocked by hostile structures. If a creep with an ATTACK body part steps on such a square,
+     * it automatically attacks the structure. The default value is false.
+     */
     ignoreDestructibleStructures?: boolean;
+
+    /**
+     * Ignore road structures. Enabling this option can speed up the search. The default value is false. This is only used when the 
+     * new PathFinder is enabled.
+     */
     ignoreRoads?: boolean;
+
+    /**
+     * You can use this callback to modify a CostMatrix for any room during the search. The callback accepts two arguments, roomName 
+     * and costMatrix. Use the costMatrix instance to make changes to the positions costs. If you return a new matrix from this callback,
+     * it will be used instead of the built-in cached one. This option is only used when the new PathFinder is enabled.
+     *
+     * @param roomName The name of the room.
+     * @param costMatrix The current CostMatrix 
+     * @returns The new CostMatrix to use
+     */
+    costCallBack?(roomName: string, costMatrix: CostMatrix): CostMatrix;
+
+    /**
+     * An array of the room's objects or RoomPosition objects which should be treated as walkable tiles during the search. This option 
+     * cannot be used when the new PathFinder is enabled (use costCallback option instead).
+     */
     ignore?: any[]|RoomPosition[];
+
+    /**
+     * An array of the room's objects or RoomPosition objects which should be treated as obstacles during the search. This option cannot 
+     * be used when the new PathFinder is enabled (use costCallback option instead).
+     */
     avoid?: any[]|RoomPosition[];
+
+    /**
+     * The maximum limit of possible pathfinding operations. You can limit CPU time used for the search based on ratio 1 op ~ 0.001 CPU.
+     * The default value is 2000.
+     */
     maxOps?: number;
+
+    /**
+     * Weight to apply to the heuristic in the A* formula F = G + weight * H. Use this option only if you understand the underlying 
+     * A* algorithm mechanics! The default value is 1.2.
+     */
     heuristicWeight?: number;
+
+    /**
+     * If true, the result path will be serialized using Room.serializePath. The default is false.
+     */
     serialize?: boolean;
+
+    /**
+     * The maximum allowed rooms to search. The default (and maximum) is 16. This is only used when the new PathFinder is enabled.
+     */
     maxRooms?: number;
 }
 
 interface MoveToOpts {
+    /**
+     * This option enables reusing the path found along multiple game ticks. It allows to save CPU time, but can result in a slightly 
+     * slower creep reaction behavior. The path is stored into the creep's memory to the _move property. The reusePath value defines 
+     * the amount of ticks which the path should be reused for. The default value is 5. Increase the amount to save more CPU, decrease 
+     * to make the movement more consistent. Set to 0 if you want to disable path reusing.
+     */
     reusePath?: number;
+
+    /**
+     * If reusePath is enabled and this option is set to true, the path will be stored in memory in the short serialized form using 
+     * Room.serializePath. The default value is true.
+     */
+    serializeMemory: boolean;
+    
+    /**
+     * If this option is set to true, moveTo method will return ERR_NOT_FOUND if there is no memorized path to reuse. This can 
+     * significantly save CPU time in some cases. The default value is false.
+     */
     noPathFinding?: boolean;
 }
 
@@ -112,3 +183,5 @@ interface SurvivalGameInfo {
      */
     wave: number;
 }
+
+

--- a/src/path-finder.ts
+++ b/src/path-finder.ts
@@ -16,7 +16,7 @@ interface PathFinder {
      * @param goal goal A RoomPosition or an object containing a RoomPosition and range
      * @param opts An object containing additional pathfinding flags.
      */
-    search(origin: RoomPosition, goal:  RoomPosition|{pos: RoomPosition, range: number}, opts?: PathFinderOps): {path: RoomPosition[], ops:number};
+    search(origin: RoomPosition, goal:  RoomPosition|{pos: RoomPosition, range: number}, opts?: PathFinderOpts): {path: RoomPosition[], ops:number};
     /**
      * Find an optimal path between origin and goal.
      *
@@ -24,7 +24,7 @@ interface PathFinder {
      * @param goal an array of goals, the cheapest path found out of all the goals will be returned.
      * @param opts An object containing additional pathfinding flags.
      */
-    search(origin: RoomPosition, goal:  RoomPosition[]|{pos: RoomPosition, range: number}[], opts?: PathFinderOps): {path: RoomPosition[], ops:number};
+    search(origin: RoomPosition, goal:  RoomPosition[]|{pos: RoomPosition, range: number}[], opts?: PathFinderOpts): {path: RoomPosition[], ops:number};
     /**
      * Specify whether to use this new experimental pathfinder in game objects methods.
      * This method should be invoked every tick. It affects the following methods behavior:
@@ -38,7 +38,7 @@ interface PathFinder {
 /**
  * An object containing additional pathfinding flags.
  */
-interface PathFinderOps {
+interface PathFinderOpts {
     /**
      * Cost for walking on plain positions. The default is 1.
      */

--- a/src/room-position.ts
+++ b/src/room-position.ts
@@ -40,13 +40,13 @@ declare class RoomPosition {
      * @param type See Room.find
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      */
-    findClosestByPath<T>(type: number, opts?: {filter?: any|string, algorithm?: string}): T;
+    findClosestByPath<T>(type: number, opts?: FindPathOpts & {filter?: any|string, algorithm?: string}): T;
     /**
      * Find an object with the shortest path from the given position. Uses A* search algorithm and Dijkstra's algorithm.
      * @param objects An array of room's objects or RoomPosition objects that the search should be executed against.
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      */
-    findClosestByPath<T>(objects: T[]|RoomPosition[], opts?: {filter?: any|string, algorithm?: string}): T;
+    findClosestByPath<T>(objects: T[]|RoomPosition[], opts?: FindPathOpts & {filter?: any|string, algorithm?: string}): T;
     /**
      * Find an object with the shortest linear distance from the given position.
      * @param type See Room.find.
@@ -65,14 +65,14 @@ declare class RoomPosition {
      * @param range The range distance.
      * @param opts See Room.find.
      */
-    findInRange<T>(type: number, range: number, opts?: {filter?: any|string, algorithm?: string}): T[];
+    findInRange<T>(type: number, range: number, opts?: {filter?: any|string}): T[];
     /**
      * Find all objects in the specified linear range.
      * @param objects An array of room's objects or RoomPosition objects that the search should be executed against.
      * @param range The range distance.
      * @param opts See Room.find.
      */
-    findInRange<T>(objects: T[]|RoomPosition[], range: number, opts?: {filter?: any|string, algorithm?: string}): T[];
+    findInRange<T>(objects: T[]|RoomPosition[], range: number, opts?: {filter?: any|string}): T[];
     /**
      * Find an optimal path to the specified position using A* search algorithm. This method is a shorthand for Room.findPath. If the target is in another room, then the corresponding exit will be used as a target.
      * @param x X position in the room.


### PR DESCRIPTION
- Changed `PathFinderOps` to `PathFinderOpts` (typo)
- Changed [`Creep.moveTo`](http://support.screeps.com/hc/en-us/articles/203013212-Creep#moveTo) `opts?` from [`PathFinderOpts`](http://support.screeps.com/hc/en-us/articles/207023879-PathFinder#search) to [`FindPathOpts`](http://support.screeps.com/hc/en-us/articles/203079011-Room#findPath)
- Changed `opts?` parameters using [`FindPathOpts`](http://support.screeps.com/hc/en-us/articles/203079011-Room#findPath) to Intersection instead of Union for:
  - [`Creep.moveTo`](http://support.screeps.com/hc/en-us/articles/203013212-Creep#moveTo)
  - [`RoomPosition.findClosestByPath`](http://support.screeps.com/hc/en-us/articles/203079201-RoomPosition#findClosestByPath)
- Removed `algorithm` from `opts?` for [`RoomPosition.findInRange`](http://support.screeps.com/hc/en-us/articles/203079201-RoomPosition#findInRange) (see [`Room.find`](http://support.screeps.com/hc/en-us/articles/203079011-Room#find))
