### PR TITLE
Update definitions

### DIFF
--- a/src/map.ts
+++ b/src/map.ts
@@ -25,7 +25,10 @@ declare class GameMap {
      * @param toRoom Finish room name or room object.
      * @returns the route array or ERR_NO_PATH code
      */
-    findRoute(fromRoom: string|Room, toRoom: string|Room): {exit: string, room: string}[]|number;
+    findRoute(fromRoom: string | Room, toRoom: string | Room, opts?: { routeCallback: { (roomName: string, fromRoomName: string): any } }): {
+        exit: string;
+        room: string;
+    }[] | number;
     /**
      * Get the linear distance (in rooms) between two rooms. You can use this function to estimate the energy cost of
      * sending resources through terminals, or using observers and nukes.

--- a/src/path-finder.ts
+++ b/src/path-finder.ts
@@ -74,7 +74,7 @@ interface PathFinderOps {
      *
      * @param roomName
      */
-    roomCallback?(roomName: string): CostMatrix;
+    roomCallback?(roomName: string): boolean | CostMatrix;
 }
 
 /**


### PR DESCRIPTION
Map.findRoute and the PathFinder.search option roomCallback had incorrect/misssing parts to there type signatures.  
