### PR TITLE
Small improvement for noImplicitAny.

### DIFF
--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,5 +1,6 @@
 // Updated 2016-02-05
 interface Memory {
+    [name: string]: any;
     creeps: {[name: string]: any};
     flags: {[name: string]: any};
     rooms: {[name: string]: any};


### PR DESCRIPTION
When using noImplicitAny in tsconfig.json, using Memory gave the message "Index signature of object type implicitly has an 'any' type".
