### PR TITLE
Added missing docblocks for structures.ts

### DIFF
--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -1945,6 +1945,10 @@ declare class Structure extends RoomObject {
      */
     notifyWhenAttacked(enabled: boolean): number;
 }
+/**
+ * The base prototype for a structure that has an owner. Such structures can be
+ * found using `FIND_MY_STRUCTURES` and `FIND_HOSTILE_STRUCTURES` constants.
+ */
 declare class OwnedStructure extends Structure {
     /**
      * Whether this is your own structure. Walls and roads don't have this property as they are considered neutral structures.
@@ -1956,7 +1960,9 @@ declare class OwnedStructure extends Structure {
     owner: Owner;
 }
 /**
- *
+ * Claim this structure to take control over the room. The controller structure
+ * cannot be damaged or destroyed. It can be addressed by `Room.controller`
+ * property.
  */
 declare class StructureController extends OwnedStructure {
     /**
@@ -1985,7 +1991,9 @@ declare class StructureController extends OwnedStructure {
     unclaim(): number;
 }
 /**
- *
+ * Contains energy which can be spent on spawning bigger creeps. Extensions can
+ * be placed anywhere in the room, any spawns will be able to use them regardless
+ * of distance.
  */
 declare class StructureExtension extends OwnedStructure {
     /**
@@ -2004,7 +2012,7 @@ declare class StructureExtension extends OwnedStructure {
     transferEnergy(target: Creep, amount?: number): number;
 }
 /**
- *
+ * Remotely transfers energy to another Link in the same room.
  */
 interface StructureLink extends OwnedStructure {
     /**
@@ -2027,7 +2035,8 @@ interface StructureLink extends OwnedStructure {
     transferEnergy(target: Creep | StructureLink, amount?: number): number;
 }
 /**
- *
+ * Non-player structure. Spawns NPC Source Keepers that guards energy sources
+ * and minerals in some rooms. This structure cannot be destroyed.
  */
 declare class StructureKeeperLair extends OwnedStructure {
     /**
@@ -2036,7 +2045,7 @@ declare class StructureKeeperLair extends OwnedStructure {
     ticksToSpawn: number;
 }
 /**
- *
+ * Provides visibility into a distant room from your script.
  */
 declare class StructureObserver extends OwnedStructure {
     /**
@@ -2059,7 +2068,8 @@ declare class StructurePowerBank extends OwnedStructure {
     ticksToDecay: number;
 }
 /**
- *
+ * Non-player structure. Contains power resource which can be obtained by
+ * destroying the structure. Hits the attacker creep back on each attack.
  */
 declare class StructurePowerSpawn extends OwnedStructure {
     /**
@@ -2095,7 +2105,8 @@ declare class StructurePowerSpawn extends OwnedStructure {
     transferEnergy(target: Creep, amount?: number): number;
 }
 /**
- *
+ * Blocks movement of hostile creeps, and defends your creeps and structures on
+ * the same tile. Can be used as a controllable gate.
  */
 declare class StructureRampart extends OwnedStructure {
     /**
@@ -2107,13 +2118,14 @@ declare class StructureRampart extends OwnedStructure {
      */
     isPublic: boolean;
     /**
-     *  Make this rampart public to allow other players' creeps to pass through.
+     * Make this rampart public to allow other players' creeps to pass through.
      * @param isPublic Whether this rampart should be public or non-public
      */
     setPublic(isPublic: boolean): any;
 }
 /**
- *
+ * Decreases movement cost to 1. Using roads allows creating creeps with less
+ * `MOVE` body parts.
  */
 declare class StructureRoad extends Structure {
     /**
@@ -2122,7 +2134,8 @@ declare class StructureRoad extends Structure {
     ticksToDecay: number;
 }
 /**
- *
+ * A structure that can store huge amount of resource units. Only one structure
+ * per room is allowed that can be addressed by `Room.storage` property.
  */
 declare class StructureStorage extends OwnedStructure {
     /**
@@ -2149,7 +2162,9 @@ declare class StructureStorage extends OwnedStructure {
     transferEnergy(target: Creep, amount?: number): number;
 }
 /**
- *
+ * Remotely attacks or heals creeps, or repairs structures. Can be targeted to
+ * any object in the room. However, its effectiveness highly depends on the
+ * distance. Each action consumes energy.
  */
 declare class StructureTower extends OwnedStructure {
     /**
@@ -2183,7 +2198,7 @@ declare class StructureTower extends OwnedStructure {
     transferEnergy(target: Creep, amount?: number): number;
 }
 /**
- *
+ * Blocks movement of all creeps.
  */
 declare class StructureWall extends Structure {
     /**
@@ -2241,7 +2256,7 @@ declare class StructureLab extends OwnedStructure {
     transfer(target: Creep, resourceType: string, amount?: number): number;
 }
 /**
- * 	Sends any resources to a Terminal in another room.
+ * Sends any resources to a Terminal in another room.
  */
 declare class StructureTerminal extends OwnedStructure {
     /**
@@ -2269,7 +2284,7 @@ declare class StructureTerminal extends OwnedStructure {
     transfer(target: Creep, resourceType: String, amount?: number): number;
 }
 /**
- * 	Contains up to 2,000 resource units. Can be constructed in neutral rooms. Decays for 5,000 hits per 100 ticks.
+ * Contains up to 2,000 resource units. Can be constructed in neutral rooms. Decays for 5,000 hits per 100 ticks.
  */
 declare class StructureContainer extends Structure {
     /**
@@ -2289,6 +2304,13 @@ declare class StructureContainer extends Structure {
      */
     transfer(target: Creep, resourceType: string, amount?: number): number;
 }
+/**
+ * Launches a nuke to another room dealing huge damage to the landing area.
+ * Each launch has a cooldown and requires energy and ghodium resources. Launching
+ * creates a Nuke object at the target room position which is visible to any player
+ * until it is landed. Incoming nuke cannot be moved or cancelled. Nukes cannot
+ * be launched from or to novice rooms.
+ */
 declare class StructureNuker extends OwnedStructure {
     /**
      * The amount of energy contained in this structure.

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -1,5 +1,3 @@
-// Updated 2016-02-05
-
 /**
  * Parent object for structure classes
  */
@@ -47,7 +45,7 @@ declare class OwnedStructure extends Structure {
     owner: Owner;
 
 }
-// Updated 2016-02-05
+
 /**
  *
  */
@@ -77,7 +75,7 @@ declare class StructureController extends OwnedStructure {
      */
     unclaim(): number;
 }
-// Updated 2016-02-05
+
 /**
  *
  */
@@ -97,7 +95,7 @@ declare class StructureExtension extends OwnedStructure {
      */
     transferEnergy(target: Creep, amount?: number): number;
 }
-// Updated 2016-02-05
+
 /**
  *
  */
@@ -121,7 +119,7 @@ interface StructureLink extends OwnedStructure {
      */
     transferEnergy(target: Creep|StructureLink, amount?: number): number;
 }
-// Updated 2016-02-05
+
 /**
  *
  */
@@ -131,7 +129,7 @@ declare class StructureKeeperLair extends OwnedStructure {
      */
     ticksToSpawn: number;
 }
-// Updated 2016-02-05
+
 /**
  *
  */
@@ -142,7 +140,7 @@ declare class StructureObserver extends OwnedStructure {
      */
     observeRoom(roomName: string): number;
 }
-// Updated 2016-02-05
+
 /**
  *
  */
@@ -156,7 +154,7 @@ declare class StructurePowerBank extends OwnedStructure {
      */
     ticksToDecay: number;
 }
-// Updated 2016-02-05
+
 /**
  *
  */
@@ -195,7 +193,7 @@ declare class StructurePowerSpawn extends OwnedStructure {
     transferEnergy(target: Creep, amount?: number): number;
 
 }
-// Updated 2016-02-05
+
 /**
  *
  */
@@ -216,7 +214,7 @@ declare class StructureRampart extends OwnedStructure {
      */
     setPublic(isPublic: boolean);
 }
-// Updated 2016-02-05
+
 /**
  *
  */
@@ -226,7 +224,7 @@ declare class StructureRoad extends Structure {
      */
     ticksToDecay: number;
 }
-// Updated 2016-02-05
+
 /**
  *
  */
@@ -256,7 +254,7 @@ declare class StructureStorage extends OwnedStructure {
      */
     transferEnergy(target: Creep, amount?: number): number;
 }
-// Updated 2016-02-05
+
 /**
  *
  */
@@ -292,6 +290,7 @@ declare class StructureTower extends OwnedStructure {
      */
     transferEnergy(target: Creep, amount?: number): number;
 }
+
 /**
  *
  */
@@ -301,12 +300,14 @@ declare class StructureWall extends Structure {
      */
     ticksToLive: number;
 }
+
 /**
  * Allows to harvest mineral deposits.
  */
 declare class StructureExtractor extends OwnedStructure {
 
 }
+
 /**
  * Produces mineral compounds from base minerals and boosts creeps.
  */
@@ -351,6 +352,7 @@ declare class StructureLab extends OwnedStructure {
      */
     transfer(target: Creep, resourceType: string, amount?: number): number;
 }
+
 /**
  * 	Sends any resources to a Terminal in another room.
  */
@@ -379,6 +381,7 @@ declare class StructureTerminal extends OwnedStructure {
      */
     transfer(target: Creep, resourceType: String, amount?: number): number;
 }
+
 /**
  * 	Contains up to 2,000 resource units. Can be constructed in neutral rooms. Decays for 5,000 hits per 100 ticks.
  */
@@ -400,6 +403,7 @@ declare class StructureContainer extends Structure{
      */
     transfer(target: Creep, resourceType: string, amount?: number): number;
 }
+
 declare class StructureNuker extends OwnedStructure {
     /**
      * The amount of energy contained in this structure.

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -2,7 +2,7 @@
  * Parent object for structure classes
  */
 
-declare class Structure extends RoomObject{
+declare class Structure extends RoomObject {
     /**
      * The current amount of hit points of the structure.
      */
@@ -34,6 +34,10 @@ declare class Structure extends RoomObject{
     notifyWhenAttacked(enabled: boolean): number;
 }
 
+/**
+ * The base prototype for a structure that has an owner. Such structures can be
+ * found using `FIND_MY_STRUCTURES` and `FIND_HOSTILE_STRUCTURES` constants.
+ */
 declare class OwnedStructure extends Structure {
     /**
      * Whether this is your own structure. Walls and roads don't have this property as they are considered neutral structures.
@@ -47,7 +51,9 @@ declare class OwnedStructure extends Structure {
 }
 
 /**
- *
+ * Claim this structure to take control over the room. The controller structure
+ * cannot be damaged or destroyed. It can be addressed by `Room.controller`
+ * property.
  */
 declare class StructureController extends OwnedStructure {
     /**
@@ -77,7 +83,9 @@ declare class StructureController extends OwnedStructure {
 }
 
 /**
- *
+ * Contains energy which can be spent on spawning bigger creeps. Extensions can
+ * be placed anywhere in the room, any spawns will be able to use them regardless
+ * of distance.
  */
 declare class StructureExtension extends OwnedStructure {
     /**
@@ -97,7 +105,7 @@ declare class StructureExtension extends OwnedStructure {
 }
 
 /**
- *
+ * Remotely transfers energy to another Link in the same room.
  */
 interface StructureLink extends OwnedStructure {
     /**
@@ -117,11 +125,12 @@ interface StructureLink extends OwnedStructure {
      * @param target The target object.
      * @param amount The amount of energy to be transferred. If omitted, all the available energy is used.
      */
-    transferEnergy(target: Creep|StructureLink, amount?: number): number;
+    transferEnergy(target: Creep | StructureLink, amount?: number): number;
 }
 
 /**
- *
+ * Non-player structure. Spawns NPC Source Keepers that guards energy sources
+ * and minerals in some rooms. This structure cannot be destroyed.
  */
 declare class StructureKeeperLair extends OwnedStructure {
     /**
@@ -131,7 +140,7 @@ declare class StructureKeeperLair extends OwnedStructure {
 }
 
 /**
- *
+ * Provides visibility into a distant room from your script.
  */
 declare class StructureObserver extends OwnedStructure {
     /**
@@ -156,7 +165,8 @@ declare class StructurePowerBank extends OwnedStructure {
 }
 
 /**
- *
+ * Non-player structure. Contains power resource which can be obtained by
+ * destroying the structure. Hits the attacker creep back on each attack.
  */
 declare class StructurePowerSpawn extends OwnedStructure {
     /**
@@ -195,7 +205,8 @@ declare class StructurePowerSpawn extends OwnedStructure {
 }
 
 /**
- *
+ * Blocks movement of hostile creeps, and defends your creeps and structures on
+ * the same tile. Can be used as a controllable gate.
  */
 declare class StructureRampart extends OwnedStructure {
     /**
@@ -209,14 +220,15 @@ declare class StructureRampart extends OwnedStructure {
     isPublic: boolean;
 
     /**
-     *  Make this rampart public to allow other players' creeps to pass through.
+     * Make this rampart public to allow other players' creeps to pass through.
      * @param isPublic Whether this rampart should be public or non-public
      */
     setPublic(isPublic: boolean);
 }
 
 /**
- *
+ * Decreases movement cost to 1. Using roads allows creating creeps with less
+ * `MOVE` body parts.
  */
 declare class StructureRoad extends Structure {
     /**
@@ -226,7 +238,8 @@ declare class StructureRoad extends Structure {
 }
 
 /**
- *
+ * A structure that can store huge amount of resource units. Only one structure
+ * per room is allowed that can be addressed by `Room.storage` property.
  */
 declare class StructureStorage extends OwnedStructure {
 
@@ -256,7 +269,9 @@ declare class StructureStorage extends OwnedStructure {
 }
 
 /**
- *
+ * Remotely attacks or heals creeps, or repairs structures. Can be targeted to
+ * any object in the room. However, its effectiveness highly depends on the
+ * distance. Each action consumes energy.
  */
 declare class StructureTower extends OwnedStructure {
     /**
@@ -282,7 +297,7 @@ declare class StructureTower extends OwnedStructure {
      * Remotely repair any structure in the room. Consumes 10 energy units per tick. Repair power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
      * @param target The target structure.
      */
-    repair(target: Spawn|Structure): number;
+    repair(target: Spawn | Structure): number;
     /**
      *
      * @param target The creep object which energy should be transferred to.
@@ -292,7 +307,7 @@ declare class StructureTower extends OwnedStructure {
 }
 
 /**
- *
+ * Blocks movement of all creeps.
  */
 declare class StructureWall extends Structure {
     /**
@@ -354,7 +369,7 @@ declare class StructureLab extends OwnedStructure {
 }
 
 /**
- * 	Sends any resources to a Terminal in another room.
+ * Sends any resources to a Terminal in another room.
  */
 declare class StructureTerminal extends OwnedStructure {
     /**
@@ -383,9 +398,9 @@ declare class StructureTerminal extends OwnedStructure {
 }
 
 /**
- * 	Contains up to 2,000 resource units. Can be constructed in neutral rooms. Decays for 5,000 hits per 100 ticks.
+ * Contains up to 2,000 resource units. Can be constructed in neutral rooms. Decays for 5,000 hits per 100 ticks.
  */
-declare class StructureContainer extends Structure{
+declare class StructureContainer extends Structure {
     /**
      * An object with the structure contents. Each object key is one of the RESOURCE_* constants, values are resources
      * amounts. Use _.sum(structure.store) to get the total amount of contents
@@ -404,6 +419,13 @@ declare class StructureContainer extends Structure{
     transfer(target: Creep, resourceType: string, amount?: number): number;
 }
 
+/**
+ * Launches a nuke to another room dealing huge damage to the landing area.
+ * Each launch has a cooldown and requires energy and ghodium resources. Launching
+ * creates a Nuke object at the target room position which is visible to any player
+ * until it is landed. Incoming nuke cannot be moved or cancelled. Nukes cannot
+ * be launched from or to novice rooms.
+ */
 declare class StructureNuker extends OwnedStructure {
     /**
      * The amount of energy contained in this structure.
@@ -429,5 +451,5 @@ declare class StructureNuker extends OwnedStructure {
      * Launch a nuke to the specified position.
      * @param pos The target room position.
      */
-    launchNuke(pos : RoomPosition): number;
+    launchNuke(pos: RoomPosition): number;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,13 @@
 {
-    "compilerOptions": {
-	"module": "system",
-	"target": "es5",
-	"sourceMap": false,
-	"declaration": true,
-	"outFile": "./dist/screeps.ts"
-    },
-    "exclude": ["node_modules", "dist"],
-    "filesGlob": [
-	"./src/**/*.ts"
-    ]
-
+  "compilerOptions": {
+    "module": "system",
+    "target": "es5",
+    "sourceMap": false,
+    "declaration": true,
+    "outFile": "./dist/screeps.ts"
+  },
+  "exclude": ["node_modules", "dist"],
+  "filesGlob": [
+    "./src/**/*.ts"
+  ]
 }


### PR DESCRIPTION
There are some documentations missing from `structure.ts` so I added all of them.

I've also made minor fixes to `tsconfig.json`, where it currently has multiple forms of indentation at once, which will mess up the file when opened in editors like Atom.
