### PR TITLE
Fixed issues with Game.notify

### DIFF
--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -946,7 +946,7 @@ interface Game {
      * @param message Custom text which will be sent in the message. Maximum length is 1000 characters.
      * @param groupInterval If set to 0 (default), the notification will be scheduled immediately. Otherwise, it will be grouped with other notifications and mailed out later using the specified time in minutes.
      */
-    notify(message: string, groupInterval: number): void;
+    notify(message: string, groupInterval?: number): void;
 }
 interface GlobalControlLevel {
     level: number;

--- a/src/game.ts
+++ b/src/game.ts
@@ -59,5 +59,5 @@ interface Game {
      * @param message Custom text which will be sent in the message. Maximum length is 1000 characters.
      * @param groupInterval If set to 0 (default), the notification will be scheduled immediately. Otherwise, it will be grouped with other notifications and mailed out later using the specified time in minutes.
      */
-    notify(message: string, groupInterval: number): void;
+    notify(message: string, groupInterval?: number): void;
 }


### PR DESCRIPTION
`Game.notify()`'s second parameter is supposed to be optional.

http://support.screeps.com/hc/en-us/articles/203016382-Game
