### PR TITLE
Fixed the name of `costCallback` in FindPathOpts

### DIFF
--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -920,7 +920,7 @@ interface FindPathOpts {
      * @param costMatrix The current CostMatrix
      * @returns The new CostMatrix to use
      */
-    costCallBack?(roomName: string, costMatrix: CostMatrix): CostMatrix;
+    costCallback?(roomName: string, costMatrix: CostMatrix): CostMatrix;
     /**
      * An array of the room's objects or RoomPosition objects which should be treated as walkable tiles during the search. This option
      * cannot be used when the new PathFinder is enabled (use costCallback option instead).

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -103,7 +103,7 @@ interface FindPathOpts {
      * @param costMatrix The current CostMatrix 
      * @returns The new CostMatrix to use
      */
-    costCallBack?(roomName: string, costMatrix: CostMatrix): CostMatrix;
+    costCallback?(roomName: string, costMatrix: CostMatrix): CostMatrix;
 
     /**
      * An array of the room's objects or RoomPosition objects which should be treated as walkable tiles during the search. This option 


### PR DESCRIPTION
Fixed the name of the `costCallback` parameter in `FindPathOpts` as per the manual at http://support.screeps.com/hc/en-us/articles/203079011-Room#findPath

Confirmed that this is actually the correct name of the parameter by running both versions against `Room.findPath()` and `Creep.moveTo()` calls with `PathFinder.use(true);` ; `costCallBack` is just ignored.
