### PR TITLE
Fixed two minor bugs in the helpers

### DIFF
--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -764,6 +764,7 @@ interface LookAtResultWithPos {
     exit?: any;
     source?: Source;
     mineral?: Mineral;
+    resource?: Resource;
 }
 interface LookAtResult {
     type: string;
@@ -776,6 +777,7 @@ interface LookAtResult {
     structure?: Structure;
     terrain?: string;
     mineral?: Mineral;
+    resource?: Resource;
 }
 interface LookAtResultMatrix {
     [coord: number]: LookAtResultMatrix | LookAtResult[];
@@ -806,7 +808,7 @@ interface FindPathOpts {
      * @param costMatrix The current CostMatrix
      * @returns The new CostMatrix to use
      */
-    costCallback?(roomName: string, costMatrix: CostMatrix): CostMatrix;
+    costCallback?(roomName: string, costMatrix: CostMatrix): boolean | CostMatrix;
     /**
      * An array of the room's objects or RoomPosition objects which should be treated as walkable tiles during the search. This option
      * cannot be used when the new PathFinder is enabled (use costCallback option instead).

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -58,6 +58,7 @@ interface LookAtResultWithPos {
     exit?: any;
     source?: Source;
     mineral?: Mineral;
+    resource? : Resource;
 }
 interface LookAtResult {
     type: string;
@@ -70,6 +71,7 @@ interface LookAtResult {
     structure?: Structure;
     terrain?: string;
     mineral?: Mineral;
+    resource?: Resource;
 }
 
 
@@ -106,7 +108,7 @@ interface FindPathOpts {
      * @param costMatrix The current CostMatrix
      * @returns The new CostMatrix to use
      */
-    costCallback?(roomName: string, costMatrix: CostMatrix): CostMatrix;
+    costCallback?(roomName: string, costMatrix: CostMatrix): boolean | CostMatrix;
 
     /**
      * An array of the room's objects or RoomPosition objects which should be treated as walkable tiles during the search. This option


### PR DESCRIPTION
Hey guys,

Great work you're doing with the declarations, really appreciated! Keep it up! 👍 

I migrated to the #TS2 branch, and only two things broke on my part, both of which I monkey patched previously on my own copy. I do believe both patches are valid though, so here goes:
#1 : A PathFinder `roomCallback` (which is dubbed `costCallback` in `FindPathOpts` ) can return `false` if a room is not to be searched. `path-finder.ts` already has the correct return value, but the `FindPathOpts` helper did not. See http://support.screeps.com/hc/en-us/articles/207023879-PathFinder#search for the docs on the callback. I quote:

>  If you return `false` from the callback the requested room will not be searched, and it won't count against `maxRooms`
#2: `lookForAt` and `lookForAtArea` (both in `Room`) can use the `LOOK_RESOURCES` constant as a parameter. That constant is defined as `LOOK_RESOURCES: "resource",`, which will result in a `resource` parameter being set in the resulting `LookAtResultWithPos` or `LookAtResult`, which was missing from the definitions.

Thanks!
