### PR TITLE
Literal types

### DIFF
--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -2,69 +2,308 @@
  * This file is Screeps API description file.
  * This might need some updates when Screeps publishes new features or changes it's existing API
  */
-declare var FIND_EXIT_TOP: number;
-declare var FIND_EXIT_RIGHT: number;
-declare var FIND_EXIT_BOTTOM: number;
-declare var FIND_EXIT_LEFT: number;
-declare var FIND_EXIT: number;
-declare var FIND_CREEPS: number;
-declare var FIND_MY_CREEPS: number;
-declare var FIND_HOSTILE_CREEPS: number;
-declare var FIND_SOURCES_ACTIVE: number;
-declare var FIND_SOURCES: number;
-declare var FIND_DROPPED_RESOURCES: number;
-declare var FIND_DROPPED_ENERGY: number;
-declare var FIND_STRUCTURES: number;
-declare var FIND_MY_STRUCTURES: number;
-declare var FIND_HOSTILE_STRUCTURES: number;
-declare var FIND_FLAGS: number;
-declare var FIND_CONSTRUCTION_SITES: number;
-declare var FIND_MY_CONSTRUCTION_SITES: number;
-declare var FIND_HOSTILE_CONSTRUCTION_SITES: number;
-declare var FIND_MY_SPAWNS: number;
-declare var FIND_HOSTILE_SPAWNS: number;
-declare var FIND_MINERALS: number;
-declare var TOP: number;
-declare var TOP_RIGHT: number;
-declare var RIGHT: number;
-declare var BOTTOM_RIGHT: number;
-declare var BOTTOM: number;
-declare var BOTTOM_LEFT: number;
-declare var LEFT: number;
-declare var TOP_LEFT: number;
-declare var OK: number;
-declare var ERR_NOT_OWNER: number;
-declare var ERR_NO_PATH: number;
-declare var ERR_NAME_EXISTS: number;
-declare var ERR_BUSY: number;
-declare var ERR_NOT_FOUND: number;
-declare var ERR_NOT_ENOUGH_RESOURCES: number;
-declare var ERR_NOT_ENOUGH_ENERGY: number;
-declare var ERR_INVALID_TARGET: number;
-declare var ERR_FULL: number;
-declare var ERR_NOT_IN_RANGE: number;
-declare var ERR_INVALID_ARGS: number;
-declare var ERR_TIRED: number;
-declare var ERR_NO_BODYPART: number;
-declare var ERR_NOT_ENOUGH_EXTENSIONS: number;
-declare var ERR_RCL_NOT_ENOUGH: number;
-declare var ERR_GCL_NOT_ENOUGH: number;
-declare var COLOR_RED: number;
-declare var COLOR_PURPLE: number;
-declare var COLOR_BLUE: number;
-declare var COLOR_CYAN: number;
-declare var COLOR_GREEN: number;
-declare var COLOR_YELLOW: number;
-declare var COLOR_ORANGE: number;
-declare var COLOR_BROWN: number;
-declare var COLOR_GREY: number;
-declare var COLOR_WHITE: number;
-declare var COLORS_ALL: number[];
+declare type FindConst = FindConstExit | FindConstExitAny | FindConstTypeCreep | FindConstTypeSource | FindConstTypeResource | FindConstTypeStructure | FindConstTypeFlag | FindConstTypeConstructionSite | FindConstTypeSpawn | FindConstTypeMineral | FindConstTypeNuke;
+declare type FindConstExit = FindConstExitTop | FindConstExitRight | FindConstExitBottom | FindConstExitLeft;
+declare type FindConstExitTop = DirConstTop;
+declare type FindConstExitRight = DirConstRight;
+declare type FindConstExitBottom = DirConstBottom;
+declare type FindConstExitLeft = DirConstLeft;
+declare type FindConstExitAny = 10;
+declare type FindConstTypeCreep = FindConstCreep | FindConstMyCreep | FindConstHostileCreep;
+declare type FindConstCreep = 101;
+declare type FindConstMyCreep = 102;
+declare type FindConstHostileCreep = 103;
+declare type FindConstTypeSource = FindConstSourceActive | FindConstSource;
+declare type FindConstSourceActive = 104;
+declare type FindConstSource = 105;
+declare type FindConstTypeResource = FindConstResource;
+declare type FindConstResource = 106;
+declare type FindConstTypeStructure = FindConstStructure | FindConstMyStructure | FindConstHostileStructure;
+declare type FindConstStructure = 107;
+declare type FindConstMyStructure = 108;
+declare type FindConstHostileStructure = 109;
+declare type FindConstTypeFlag = FindConstFlag;
+declare type FindConstFlag = 110;
+declare type FindConstTypeConstructionSite = FindConstConstructionSite | FindConstMyConstructionSite | FindConstHostileConstructionSite;
+declare type FindConstConstructionSite = 111;
+declare type FindConstMyConstructionSite = 114;
+declare type FindConstHostileConstructionSite = 115;
+declare type FindConstTypeSpawn = FindConstMySpawn | FindConstHostileSpawn;
+declare type FindConstMySpawn = 112;
+declare type FindConstHostileSpawn = 113;
+declare type FindConstTypeMineral = FindConstMineral;
+declare type FindConstMineral = 116;
+declare type FindConstTypeNuke = FindConstNuke;
+declare type FindConstNuke = 117;
+declare var FIND_EXIT_TOP: FindConstExitTop;
+declare var FIND_EXIT_RIGHT: FindConstExitRight;
+declare var FIND_EXIT_BOTTOM: FindConstExitBottom;
+declare var FIND_EXIT_LEFT: FindConstExitLeft;
+declare var FIND_EXIT: FindConstExitAny;
+declare var FIND_CREEPS: FindConstCreep;
+declare var FIND_MY_CREEPS: FindConstMyCreep;
+declare var FIND_HOSTILE_CREEPS: FindConstHostileCreep;
+declare var FIND_SOURCES_ACTIVE: FindConstSourceActive;
+declare var FIND_SOURCES: FindConstSource;
+declare var FIND_DROPPED_ENERGY: FindConstResource;
+declare var FIND_DROPPED_RESOURCES: FindConstResource;
+declare var FIND_STRUCTURES: FindConstStructure;
+declare var FIND_MY_STRUCTURES: FindConstMyStructure;
+declare var FIND_HOSTILE_STRUCTURES: FindConstHostileStructure;
+declare var FIND_FLAGS: FindConstFlag;
+declare var FIND_CONSTRUCTION_SITES: FindConstConstructionSite;
+declare var FIND_MY_SPAWNS: FindConstMySpawn;
+declare var FIND_HOSTILE_SPAWNS: FindConstHostileSpawn;
+declare var FIND_MY_CONSTRUCTION_SITES: FindConstMyConstructionSite;
+declare var FIND_HOSTILE_CONSTRUCTION_SITES: FindConstHostileConstructionSite;
+declare var FIND_MINERALS: FindConstMineral;
+declare var FIND_NUKES: FindConstNuke;
+declare type DirConst = DirConstTop | DirConstTopRight | DirConstRight | DirConstBottomRight | DirConstBottom | DirConstBottomLeft | DirConstLeft | DirConstTopLeft;
+declare type DirConstTop = 1;
+declare type DirConstTopRight = 2;
+declare type DirConstRight = 3;
+declare type DirConstBottomRight = 4;
+declare type DirConstBottom = 5;
+declare type DirConstBottomLeft = 6;
+declare type DirConstLeft = 7;
+declare type DirConstTopLeft = 8;
+declare var TOP: DirConstTop;
+declare var TOP_RIGHT: DirConstTopRight;
+declare var RIGHT: DirConstRight;
+declare var BOTTOM_RIGHT: DirConstBottomRight;
+declare var BOTTOM: DirConstBottom;
+declare var BOTTOM_LEFT: DirConstBottomLeft;
+declare var LEFT: DirConstLeft;
+declare var TOP_LEFT: DirConstTopLeft;
+declare type ReturnConst = ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrNoPath | ReturnConstErrNameExists | ReturnConstErrBusy | ReturnConstErrNotFound | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrNotInRange | ReturnConstErrInvalidArgs | ReturnConstErrTired | ReturnConstErrNoBodypart | ReturnConstErrRCL | ReturnConstErrGCL;
+declare type ReturnConstOk = 0;
+declare type ReturnConstErrNotOwner = -1;
+declare type ReturnConstErrNoPath = -2;
+declare type ReturnConstErrNameExists = -3;
+declare type ReturnConstErrBusy = -4;
+declare type ReturnConstErrNotFound = -5;
+declare type ReturnConstErrNotEnough = -6;
+declare type ReturnConstErrInvalidTarget = -7;
+declare type ReturnConstErrFull = -8;
+declare type ReturnConstErrNotInRange = -9;
+declare type ReturnConstErrInvalidArgs = -10;
+declare type ReturnConstErrTired = -11;
+declare type ReturnConstErrNoBodypart = -12;
+declare type ReturnConstErrRCL = -14;
+declare type ReturnConstErrGCL = -15;
+declare var OK: ReturnConstOk;
+declare var ERR_NOT_OWNER: ReturnConstErrNotOwner;
+declare var ERR_NO_PATH: ReturnConstErrNoPath;
+declare var ERR_NAME_EXISTS: ReturnConstErrNameExists;
+declare var ERR_BUSY: ReturnConstErrBusy;
+declare var ERR_NOT_FOUND: ReturnConstErrNotFound;
+declare var ERR_NOT_ENOUGH_RESOURCES: ReturnConstErrNotEnough;
+declare var ERR_NOT_ENOUGH_ENERGY: ReturnConstErrNotEnough;
+declare var ERR_INVALID_TARGET: ReturnConstErrInvalidTarget;
+declare var ERR_FULL: ReturnConstErrFull;
+declare var ERR_NOT_IN_RANGE: ReturnConstErrNotInRange;
+declare var ERR_INVALID_ARGS: ReturnConstErrInvalidArgs;
+declare var ERR_TIRED: ReturnConstErrTired;
+declare var ERR_NO_BODYPART: ReturnConstErrNoBodypart;
+declare var ERR_NOT_ENOUGH_EXTENSIONS: ReturnConstErrNotEnough;
+declare var ERR_RCL_NOT_ENOUGH: ReturnConstErrRCL;
+declare var ERR_GCL_NOT_ENOUGH: ReturnConstErrGCL;
+declare type ColorConst = ColorConstRed | ColorConstPurple | ColorConstBlue | ColorConstCyan | ColorConstGreen | ColorConstYellow | ColorConstOrange | ColorConstBrown | ColorConstGrey | ColorConstWhite;
+declare type ColorConstRed = 1;
+declare type ColorConstPurple = 2;
+declare type ColorConstBlue = 3;
+declare type ColorConstCyan = 4;
+declare type ColorConstGreen = 5;
+declare type ColorConstYellow = 6;
+declare type ColorConstOrange = 7;
+declare type ColorConstBrown = 8;
+declare type ColorConstGrey = 9;
+declare type ColorConstWhite = 10;
+declare var COLOR_RED: ColorConstRed;
+declare var COLOR_PURPLE: ColorConstPurple;
+declare var COLOR_BLUE: ColorConstBlue;
+declare var COLOR_CYAN: ColorConstCyan;
+declare var COLOR_GREEN: ColorConstGreen;
+declare var COLOR_YELLOW: ColorConstYellow;
+declare var COLOR_ORANGE: ColorConstOrange;
+declare var COLOR_BROWN: ColorConstBrown;
+declare var COLOR_GREY: ColorConstGrey;
+declare var COLOR_WHITE: ColorConstWhite;
+declare var COLORS_ALL: ColorConst[];
+declare type LookConst = LookConstCreep | LookConstEnergy | LookConstResource | LookConstSource | LookConstMineral | LookConstStructure | LookConstFlag | LookConstConstructionSite | LookConstNuke | LookConstTerrain;
+declare type LookConstCreep = "creep";
+declare type LookConstEnergy = "energy";
+declare type LookConstResource = "resource";
+declare type LookConstSource = "source";
+declare type LookConstMineral = "mineral";
+declare type LookConstStructure = "structure";
+declare type LookConstFlag = "flag";
+declare type LookConstConstructionSite = "constructionSite";
+declare type LookConstNuke = "nuke";
+declare type LookConstTerrain = "terrain";
+declare var LOOK_CREEPS: LookConstCreep;
+declare var LOOK_ENERGY: LookConstEnergy;
+declare var LOOK_RESOURCES: LookConstResource;
+declare var LOOK_SOURCES: LookConstSource;
+declare var LOOK_MINERALS: LookConstMineral;
+declare var LOOK_STRUCTURES: LookConstStructure;
+declare var LOOK_FLAGS: LookConstFlag;
+declare var LOOK_CONSTRUCTION_SITES: LookConstConstructionSite;
+declare var LOOK_NUKES: LookConstNuke;
+declare var LOOK_TERRAIN: LookConstTerrain;
+declare type BodypartConst = BodypartConstMove | BodypartConstWork | BodypartConstCarry | BodypartConstAttack | BodypartConstRangedAttack | BodypartConstTough | BodypartConstHeal | BodypartConstClaim;
+declare type BodypartConstMove = "move";
+declare type BodypartConstWork = "work";
+declare type BodypartConstCarry = "carry";
+declare type BodypartConstAttack = "attack";
+declare type BodypartConstRangedAttack = "ranged_attack";
+declare type BodypartConstTough = "tough";
+declare type BodypartConstHeal = "heal";
+declare type BodypartConstClaim = "claim";
+declare var MOVE: BodypartConstMove;
+declare var WORK: BodypartConstWork;
+declare var CARRY: BodypartConstCarry;
+declare var ATTACK: BodypartConstAttack;
+declare var RANGED_ATTACK: BodypartConstRangedAttack;
+declare var TOUGH: BodypartConstTough;
+declare var HEAL: BodypartConstHeal;
+declare var CLAIM: BodypartConstClaim;
+declare var BODYPARTS_ALL: BodypartConst[];
+declare type StructureConst = StructureConstSpawn | StructureConstExtension | StructureConstRoad | StructureConstWall | StructureConstRampart | StructureConstKeeperLair | StructureConstPortal | StructureConstController | StructureConstLink | StructureConstStorage | StructureConstTower | StructureConstObserver | StructureConstPowerBank | StructureConstPowerSpawn | StructureConstExtractor | StructureConstLab | StructureConstTerminal | StructureConstContainer | StructureConstNuker;
+declare type StructureConstSpawn = "spawn";
+declare type StructureConstExtension = "extension";
+declare type StructureConstRoad = "road";
+declare type StructureConstWall = "constructedWall";
+declare type StructureConstRampart = "rampart";
+declare type StructureConstKeeperLair = "keeperLair";
+declare type StructureConstPortal = "portal";
+declare type StructureConstController = "controller";
+declare type StructureConstLink = "link";
+declare type StructureConstStorage = "storage";
+declare type StructureConstTower = "tower";
+declare type StructureConstObserver = "observer";
+declare type StructureConstPowerBank = "powerBank";
+declare type StructureConstPowerSpawn = "powerSpawn";
+declare type StructureConstExtractor = "extractor";
+declare type StructureConstLab = "lab";
+declare type StructureConstTerminal = "terminal";
+declare type StructureConstContainer = "container";
+declare type StructureConstNuker = "nuker";
+declare var STRUCTURE_SPAWN: StructureConstSpawn;
+declare var STRUCTURE_EXTENSION: StructureConstExtension;
+declare var STRUCTURE_ROAD: StructureConstRoad;
+declare var STRUCTURE_WALL: StructureConstWall;
+declare var STRUCTURE_RAMPART: StructureConstRampart;
+declare var STRUCTURE_KEEPER_LAIR: StructureConstKeeperLair;
+declare var STRUCTURE_PORTAL: StructureConstPortal;
+declare var STRUCTURE_CONTROLLER: StructureConstController;
+declare var STRUCTURE_LINK: StructureConstLink;
+declare var STRUCTURE_STORAGE: StructureConstStorage;
+declare var STRUCTURE_TOWER: StructureConstTower;
+declare var STRUCTURE_OBSERVER: StructureConstObserver;
+declare var STRUCTURE_POWER_BANK: StructureConstPowerBank;
+declare var STRUCTURE_POWER_SPAWN: StructureConstPowerSpawn;
+declare var STRUCTURE_EXTRACTOR: StructureConstExtractor;
+declare var STRUCTURE_LAB: StructureConstLab;
+declare var STRUCTURE_TERMINAL: StructureConstTerminal;
+declare var STRUCTURE_CONTAINER: StructureConstContainer;
+declare var STRUCTURE_NUKER: StructureConstNuker;
+declare type ObjectConst = StructureConst | "creep" | "wall";
+declare type ResourceConst = ResourceConstEnergy | ResourceConstPower | ResourceConstH | ResourceConstO | ResourceConstU | ResourceConstL | ResourceConstK | ResourceConstZ | ResourceConstX | ResourceConstG | ResourceConstOH | ResourceConstZK | ResourceConstUL | ResourceConstUH | ResourceConstUO | ResourceConstKH | ResourceConstKO | ResourceConstLH | ResourceConstLO | ResourceConstZH | ResourceConstZO | ResourceConstGH | ResourceConstGO | ResourceConstUH2O | ResourceConstUHO2 | ResourceConstKH2O | ResourceConstKHO2 | ResourceConstLH2O | ResourceConstLHO2 | ResourceConstZH2O | ResourceConstZHO2 | ResourceConstGH2O | ResourceConstGHO2 | ResourceConstXUH2O | ResourceConstXUHO2 | ResourceConstXKH2O | ResourceConstXKHO2 | ResourceConstXLH2O | ResourceConstXLHO2 | ResourceConstXZH2O | ResourceConstXZHO2 | ResourceConstXGH2O | ResourceConstXGHO2;
+declare type ResourceConstEnergy = "energy";
+declare type ResourceConstPower = "power";
+declare type ResourceConstH = "H";
+declare type ResourceConstO = "O";
+declare type ResourceConstU = "U";
+declare type ResourceConstL = "L";
+declare type ResourceConstK = "K";
+declare type ResourceConstZ = "Z";
+declare type ResourceConstX = "X";
+declare type ResourceConstG = "G";
+declare type ResourceConstOH = "OH";
+declare type ResourceConstZK = "ZK";
+declare type ResourceConstUL = "UL";
+declare type ResourceConstUH = "UH";
+declare type ResourceConstUO = "UO";
+declare type ResourceConstKH = "KH";
+declare type ResourceConstKO = "KO";
+declare type ResourceConstLH = "LH";
+declare type ResourceConstLO = "LO";
+declare type ResourceConstZH = "ZH";
+declare type ResourceConstZO = "ZO";
+declare type ResourceConstGH = "GH";
+declare type ResourceConstGO = "GO";
+declare type ResourceConstUH2O = "UH2O";
+declare type ResourceConstUHO2 = "UHO2";
+declare type ResourceConstKH2O = "KH2O";
+declare type ResourceConstKHO2 = "KHO2";
+declare type ResourceConstLH2O = "LH2O";
+declare type ResourceConstLHO2 = "LHO2";
+declare type ResourceConstZH2O = "ZH2O";
+declare type ResourceConstZHO2 = "ZHO2";
+declare type ResourceConstGH2O = "GH2O";
+declare type ResourceConstGHO2 = "GHO2";
+declare type ResourceConstXUH2O = "XUH2O";
+declare type ResourceConstXUHO2 = "XUHO2";
+declare type ResourceConstXKH2O = "XKH2O";
+declare type ResourceConstXKHO2 = "XKHO2";
+declare type ResourceConstXLH2O = "XLH2O";
+declare type ResourceConstXLHO2 = "XLHO2";
+declare type ResourceConstXZH2O = "XZH2O";
+declare type ResourceConstXZHO2 = "XZHO2";
+declare type ResourceConstXGH2O = "XGH2O";
+declare type ResourceConstXGHO2 = "XGHO2";
+declare type SubscriptionTokenConst = "token";
+declare var RESOURCE_ENERGY: ResourceConstEnergy;
+declare var RESOURCE_POWER: ResourceConstPower;
+declare var RESOURCE_HYDROGEN: ResourceConstH;
+declare var RESOURCE_OXYGEN: ResourceConstO;
+declare var RESOURCE_UTRIUM: ResourceConstU;
+declare var RESOURCE_LEMERGIUM: ResourceConstL;
+declare var RESOURCE_KEANIUM: ResourceConstK;
+declare var RESOURCE_ZYNTHIUM: ResourceConstZ;
+declare var RESOURCE_CATALYST: ResourceConstX;
+declare var RESOURCE_GHODIUM: ResourceConstG;
+declare var RESOURCE_HYDROXIDE: ResourceConstOH;
+declare var RESOURCE_ZYNTHIUM_KEANITE: ResourceConstZK;
+declare var RESOURCE_UTRIUM_LEMERGITE: ResourceConstUL;
+declare var RESOURCE_UTRIUM_HYDRIDE: ResourceConstUH;
+declare var RESOURCE_UTRIUM_OXIDE: ResourceConstUO;
+declare var RESOURCE_KEANIUM_HYDRIDE: ResourceConstKH;
+declare var RESOURCE_KEANIUM_OXIDE: ResourceConstKO;
+declare var RESOURCE_LEMERGIUM_HYDRIDE: ResourceConstLH;
+declare var RESOURCE_LEMERGIUM_OXIDE: ResourceConstLO;
+declare var RESOURCE_ZYNTHIUM_HYDRIDE: ResourceConstZH;
+declare var RESOURCE_ZYNTHIUM_OXIDE: ResourceConstZO;
+declare var RESOURCE_GHODIUM_HYDRIDE: ResourceConstGH;
+declare var RESOURCE_GHODIUM_OXIDE: ResourceConstGO;
+declare var RESOURCE_UTRIUM_ACID: ResourceConstUH2O;
+declare var RESOURCE_UTRIUM_ALKALIDE: ResourceConstUHO2;
+declare var RESOURCE_KEANIUM_ACID: ResourceConstKH2O;
+declare var RESOURCE_KEANIUM_ALKALIDE: ResourceConstKHO2;
+declare var RESOURCE_LEMERGIUM_ACID: ResourceConstLH2O;
+declare var RESOURCE_LEMERGIUM_ALKALIDE: ResourceConstLHO2;
+declare var RESOURCE_ZYNTHIUM_ACID: ResourceConstZH2O;
+declare var RESOURCE_ZYNTHIUM_ALKALIDE: ResourceConstZHO2;
+declare var RESOURCE_GHODIUM_ACID: ResourceConstGH2O;
+declare var RESOURCE_GHODIUM_ALKALIDE: ResourceConstGHO2;
+declare var RESOURCE_CATALYZED_UTRIUM_ACID: ResourceConstXUH2O;
+declare var RESOURCE_CATALYZED_UTRIUM_ALKALIDE: ResourceConstXUHO2;
+declare var RESOURCE_CATALYZED_KEANIUM_ACID: ResourceConstXKH2O;
+declare var RESOURCE_CATALYZED_KEANIUM_ALKALIDE: ResourceConstXKHO2;
+declare var RESOURCE_CATALYZED_LEMERGIUM_ACID: ResourceConstXLH2O;
+declare var RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE: ResourceConstXLHO2;
+declare var RESOURCE_CATALYZED_ZYNTHIUM_ACID: ResourceConstXZH2O;
+declare var RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE: ResourceConstXZHO2;
+declare var RESOURCE_CATALYZED_GHODIUM_ACID: ResourceConstXGH2O;
+declare var RESOURCE_CATALYZED_GHODIUM_ALKALIDE: ResourceConstXGHO2;
+declare var RESOURCES_ALL: ResourceConst[];
+declare type TerrainConst = "plain" | "swamp" | "wall";
 declare var CREEP_SPAWN_TIME: number;
 declare var CREEP_LIFE_TIME: number;
 declare var CREEP_CLAIM_LIFE_TIME: number;
 declare var CREEP_CORPSE_RATE: number;
-declare var OBSTACLE_OBJECT_TYPES: string[];
+declare var OBSTACLE_OBJECT_TYPES: ObjectConst[];
 declare var ENERGY_REGEN_TIME: number;
 declare var ENERGY_DECAY: number;
 declare var CREEP_CORPSE_RATE: number;
@@ -113,7 +352,6 @@ declare var BODYPART_COST: {
     tough: number;
     claim: number;
 };
-declare var BODYPARTS_ALL: string[];
 declare var CARRY_CAPACITY: number;
 declare var HARVEST_POWER: number;
 declare var HARVEST_MINERAL_POWER: number;
@@ -126,14 +364,6 @@ declare var RANGED_ATTACK_POWER: number;
 declare var HEAL_POWER: number;
 declare var RANGED_HEAL_POWER: number;
 declare var DISMANTLE_COST: number;
-declare var MOVE: string;
-declare var WORK: string;
-declare var CARRY: string;
-declare var ATTACK: string;
-declare var RANGED_ATTACK: string;
-declare var TOUGH: string;
-declare var HEAL: string;
-declare var CLAIM: string;
 declare var CONSTRUCTION_COST: {
     spawn: number;
     extension: number;
@@ -151,70 +381,7 @@ declare var CONSTRUCTION_COST: {
     container: number;
 };
 declare var CONSTRUCTION_COST_ROAD_SWAMP_RATIO: number;
-declare var STRUCTURE_EXTENSION: string;
-declare var STRUCTURE_RAMPART: string;
-declare var STRUCTURE_ROAD: string;
-declare var STRUCTURE_SPAWN: string;
-declare var STRUCTURE_LINK: string;
-declare var STRUCTURE_WALL: string;
-declare var STRUCTURE_KEEPER_LAIR: string;
-declare var STRUCTURE_CONTROLLER: string;
-declare var STRUCTURE_STORAGE: string;
-declare var STRUCTURE_TOWER: string;
-declare var STRUCTURE_OBSERVER: string;
-declare var STRUCTURE_POWER_BANK: string;
-declare var STRUCTURE_POWER_SPAWN: string;
-declare var STRUCTURE_EXTRACTOR: string;
-declare var STRUCTURE_LAB: string;
-declare var STRUCTURE_TERMINAL: string;
-declare var STRUCTURE_CONTAINER: string;
-declare var STRUCTURE_NUKER: string;
-declare var STRUCTURE_PORTAL: string;
-declare var RESOURCE_ENERGY: string;
-declare var RESOURCE_POWER: string;
-declare var RESOURCE_UTRIUM: string;
-declare var RESOURCE_LEMERGIUM: string;
-declare var RESOURCE_KEANIUM: string;
-declare var RESOURCE_GHODIUM: string;
-declare var RESOURCE_ZYNTHIUM: string;
-declare var RESOURCE_OXYGEN: string;
-declare var RESOURCE_HYDROGEN: string;
-declare var RESOURCE_CATALYST: string;
-declare var RESOURCE_HYDROXIDE: string;
-declare var RESOURCE_ZYNTHIUM_KEANITE: string;
-declare var RESOURCE_UTRIUM_LEMERGITE: string;
-declare var RESOURCE_UTRIUM_HYDRIDE: string;
-declare var RESOURCE_UTRIUM_OXIDE: string;
-declare var RESOURCE_KEANIUM_HYDRIDE: string;
-declare var RESOURCE_KEANIUM_OXIDE: string;
-declare var RESOURCE_LEMERGIUM_HYDRIDE: string;
-declare var RESOURCE_LEMERGIUM_OXIDE: string;
-declare var RESOURCE_ZYNTHIUM_HYDRIDE: string;
-declare var RESOURCE_ZYNTHIUM_OXIDE: string;
-declare var RESOURCE_GHODIUM_HYDRIDE: string;
-declare var RESOURCE_GHODIUM_OXIDE: string;
-declare var RESOURCE_UTRIUM_ACID: string;
-declare var RESOURCE_UTRIUM_ALKALIDE: string;
-declare var RESOURCE_KEANIUM_ACID: string;
-declare var RESOURCE_KEANIUM_ALKALIDE: string;
-declare var RESOURCE_LEMERGIUM_ACID: string;
-declare var RESOURCE_LEMERGIUM_ALKALIDE: string;
-declare var RESOURCE_ZYNTHIUM_ACID: string;
-declare var RESOURCE_ZYNTHIUM_ALKALIDE: string;
-declare var RESOURCE_GHODIUM_ACID: string;
-declare var RESOURCE_GHODIUM_ALKALIDE: string;
-declare var RESOURCE_CATALYZED_UTRIUM_ACID: string;
-declare var RESOURCE_CATALYZED_UTRIUM_ALKALIDE: string;
-declare var RESOURCE_CATALYZED_KEANIUM_ACID: string;
-declare var RESOURCE_CATALYZED_KEANIUM_ALKALIDE: string;
-declare var RESOURCE_CATALYZED_LEMERGIUM_ACID: string;
-declare var RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE: string;
-declare var RESOURCE_CATALYZED_ZYNTHIUM_ACID: string;
-declare var RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE: string;
-declare var RESOURCE_CATALYZED_GHODIUM_ACID: string;
-declare var RESOURCE_CATALYZED_GHODIUM_ALKALIDE: string;
-declare var RESOURCES_ALL: string[];
-declare var SUBSCRIPTION_TOKEN: string;
+declare var SUBSCRIPTION_TOKEN: SubscriptionTokenConst;
 declare var CONTROLLER_LEVELS: {
     [level: number]: number;
 };
@@ -262,10 +429,15 @@ declare var LAB_COOLDOWN: number;
 declare var GCL_POW: number;
 declare var GCL_MULTIPLY: number;
 declare var GCL_NOVICE: number;
-declare var MODE_SIMULATION: string;
-declare var MODE_SURVIVAL: string;
-declare var MODE_WORLD: string;
-declare var MODE_ARENA: string;
+declare type ModeConst = ModeConstSimulation | ModeConstSurvival | ModeConstWorld | ModeConstArena;
+declare type ModeConstSimulation = "simulation";
+declare type ModeConstSurvival = "survival";
+declare type ModeConstWorld = "world";
+declare type ModeConstArena = "arena";
+declare var MODE_SIMULATION: ModeConstSimulation;
+declare var MODE_SURVIVAL: ModeConstSurvival;
+declare var MODE_WORLD: ModeConstWorld;
+declare var MODE_ARENA: ModeConstArena;
 declare var TERRAIN_MASK_WALL: number;
 declare var TERRAIN_MASK_SWAMP: number;
 declare var TERRAIN_MASK_LAVA: number;
@@ -304,7 +476,7 @@ declare var NUKE_DAMAGE: {
 };
 declare var REACTIONS: {
     [reagent: string]: {
-        [reagent: string]: string;
+        [reagent: string]: ResourceConst;
     };
 };
 declare var BOOSTS: {
@@ -314,18 +486,11 @@ declare var BOOSTS: {
         };
     };
 };
-declare var LOOK_CREEPS: string;
-declare var LOOK_ENERGY: string;
-declare var LOOK_RESOURCES: string;
-declare var LOOK_SOURCES: string;
-declare var LOOK_MINERALS: string;
-declare var LOOK_STRUCTURES: string;
-declare var LOOK_FLAGS: string;
-declare var LOOK_CONSTRUCTION_SITES: string;
-declare var LOOK_NUKES: string;
-declare var LOOK_TERRAIN: string;
-declare var ORDER_SELL: string;
-declare var ORDER_BUY: string;
+declare type OrderConst = OrderConstSell | OrderConstBuy;
+declare type OrderConstSell = "sell";
+declare type OrderConstBuy = "buy";
+declare var ORDER_SELL: OrderConstSell;
+declare var ORDER_BUY: OrderConstBuy;
 /**
  * A site of a structure which is currently under construction.
  */
@@ -352,14 +517,14 @@ interface ConstructionSite extends RoomObject {
      */
     progressTotal: number;
     /**
-     * One of the following constants: STRUCTURE_EXTENSION, STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_SPAWN, STRUCTURE_WALL, STRUCTURE_LINK
+     * One of the STRUCTURE_* constants.
      */
-    structureType: string;
+    structureType: StructureConst;
     /**
      * Remove the construction site.
      * @returns Result Code: OK, ERR_NOT_OWNER
      */
-    remove(): number;
+    remove(): ReturnConstOk | ReturnConstErrNotOwner;
 }
 interface ConstructionSiteConstructor extends _Constructor<ConstructionSite>, _ConstructorById<ConstructionSite> {
 }
@@ -383,11 +548,17 @@ declare type Spawn = StructureSpawn;
 declare const Spawn: StructureSpawnConstructor;
 interface Storage extends StructureStorage {
 }
+declare type StandardCreepReturn = ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrBusy | ReturnConstErrNoBodypart;
+declare type TargetCreepReturn = StandardCreepReturn | ReturnConstErrInvalidTarget | ReturnConstErrNotInRange;
 /**
  * Creeps are your units. Creeps can move, harvest energy, construct structures, attack another creeps, and perform other actions. Each creep consists of up to 50 body parts with the following possible types:
  */
 interface Creep extends RoomObject {
     readonly prototype: Creep;
+    /**
+     * Room cannot be undefined for a Creep.
+     */
+    room: Room;
     /**
      * An array describing the creep’s body. Each element contains the following properties:
      * type: string
@@ -395,7 +566,7 @@ interface Creep extends RoomObject {
      * hits: number
      * The remaining amount of hit points of this body part.
      */
-    body: BodyPartDefinition[];
+    body: BodypartDefinition[];
     /**
      * An object with the creep's cargo contents:
      * energy: number
@@ -454,73 +625,73 @@ interface Creep extends RoomObject {
      * Attack another creep or structure in a short-ranged attack. Needs the ATTACK body part. If the target is inside a rampart, then the rampart is attacked instead. The target has to be at adjacent square to the creep. If the target is a creep with ATTACK body parts and is not inside a rampart, it will automatically hit back at the attacker.
      * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART
      */
-    attack(target: Creep | Spawn | Structure): number;
+    attack(target: Creep | Structure): TargetCreepReturn;
     /**
      * Decreases the controller's downgrade or reservation timer for 1 tick per every 5 CLAIM body parts (so the creep must have at least 5xCLAIM). The controller under attack cannot be upgraded for the next 1,000 ticks. The target has to be at adjacent square to the creep.
      * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART
      */
-    attackController(target: Structure): number;
+    attackController(target: StructureController): TargetCreepReturn;
     /**
      * Build a structure at the target construction site using carried energy. Needs WORK and CARRY body parts. The target has to be within 3 squares range of the creep.
      * @param target The target object to be attacked.
      * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_NOT_ENOUGH_RESOURCES, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART, ERR_RCL_NOT_ENOUGH
      */
-    build(target: ConstructionSite): number;
+    build(target: ConstructionSite): TargetCreepReturn | ReturnConstErrNotEnough | ReturnConstErrRCL;
     /**
      * Cancel the order given during the current game tick.
      * @param methodName The name of a creep's method to be cancelled.
      * @returns Result Code: OK, ERR_NOT_FOUND
      */
-    cancelOrder(methodName: string): number;
+    cancelOrder(methodName: string): ReturnConstOk | ReturnConstErrNotFound;
     /**
      * Requires the CLAIM body part. If applied to a neutral controller, claims it under your control. If applied to a hostile controller, decreases its downgrade or reservation timer depending on the CLAIM body parts count. The target has to be at adjacent square to the creep.
      * @param target The target controller object.
      * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_FULL, ERR_NOT_IN_RANGE, ERR_NO_BODYPART, ERR_GCL_NOT_ENOUGH
      */
-    claimController(target: Controller): number;
+    claimController(target: StructureController): TargetCreepReturn | ReturnConstErrFull | ReturnConstErrGCL;
     /**
      * Dismantles any (even hostile) structure returning 50% of the energy spent on its repair. Requires the WORK body part. If the creep has an empty CARRY body part, the energy is put into it; otherwise it is dropped on the ground. The target has to be at adjacent square to the creep.
      * @param target The target structure.
      */
-    dismantle(target: Spawn | Structure): number;
+    dismantle(target: Structure): TargetCreepReturn;
     /**
      * Drop this resource on the ground.
      * @param resourceType One of the RESOURCE_* constants.
      * @param amount The amount of resource units to be dropped. If omitted, all the available carried amount is used.
      */
-    drop(resourceType: string, amount?: number): number;
+    drop(resourceType: ResourceConst, amount?: number): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrBusy | ReturnConstErrNotEnough;
     /**
      * Get the quantity of live body parts of the given type. Fully damaged parts do not count.
      * @param type A body part type, one of the following body part constants: MOVE, WORK, CARRY, ATTACK, RANGED_ATTACK, HEAL, TOUGH, CLAIM
      */
-    getActiveBodyparts(type: string): number;
+    getActiveBodyparts(type: BodypartConst): number;
     /**
      * Harvest energy from the source. Needs the WORK body part. If the creep has an empty CARRY body part, the harvested energy is put into it; otherwise it is dropped on the ground. The target has to be at an adjacent square to the creep.
      * @param target The source object to be harvested.
      */
-    harvest(target: Source | Mineral): number;
+    harvest(target: Source | Mineral): TargetCreepReturn | ReturnConstErrNotFound | ReturnConstErrNotEnough;
     /**
      * Heal self or another creep. It will restore the target creep’s damaged body parts function and increase the hits counter. Needs the HEAL body part. The target has to be at adjacent square to the creep.
      * @param target The target creep object.
      */
-    heal(target: Creep): number;
+    heal(target: Creep): TargetCreepReturn;
     /**
      * Move the creep one square in the specified direction. Needs the MOVE body part.
      * @param direction
      */
-    move(direction: number): number;
+    move(direction: DirConst): StandardCreepReturn | ReturnConstErrTired;
     /**
      * Move the creep using the specified predefined path. Needs the MOVE body part.
      * @param path A path value as returned from Room.findPath or RoomPosition.findPathTo methods. Both array form and serialized string form are accepted.
      */
-    moveByPath(path: PathStep[] | RoomPosition[] | string): number;
+    moveByPath(path: PathStep[] | RoomPosition[] | string): StandardCreepReturn | ReturnConstErrNotFound | ReturnConstErrInvalidArgs | ReturnConstErrTired;
     /**
      * Find the optimal path to the target within the same room and move to it. A shorthand to consequent calls of pos.findPathTo() and move() methods. If the target is in another room, then the corresponding exit will be used as a target. Needs the MOVE body part.
      * @param x X position of the target in the room.
      * @param y Y position of the target in the room.
      * @param opts An object containing pathfinding options flags (see Room.findPath for more info) or one of the following: reusePath, serializeMemory, noPathFinding
      */
-    moveTo(x: number, y: number, opts?: MoveToOpts & FindPathOpts): number;
+    moveTo(x: number, y: number, opts?: MoveToOpts & FindPathOpts): StandardCreepReturn | ReturnConstErrTired | ReturnConstErrInvalidTarget | ReturnConstErrNoPath;
     /**
      * Find the optimal path to the target within the same room and move to it. A shorthand to consequent calls of pos.findPathTo() and move() methods. If the target is in another room, then the corresponding exit will be used as a target. Needs the MOVE body part.
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
@@ -528,71 +699,71 @@ interface Creep extends RoomObject {
      */
     moveTo(target: RoomPosition | {
         pos: RoomPosition;
-    }, opts?: MoveToOpts & FindPathOpts): number;
+    }, opts?: MoveToOpts & FindPathOpts): StandardCreepReturn | ReturnConstErrTired | ReturnConstErrInvalidTarget | ReturnConstErrNoPath;
     /**
      * Toggle auto notification when the creep is under attack. The notification will be sent to your account email. Turned on by default.
      * @param enabled Whether to enable notification or disable.
      */
-    notifyWhenAttacked(enabled: boolean): number;
+    notifyWhenAttacked(enabled: boolean): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrInvalidArgs;
     /**
      * Pick up an item (a dropped piece of energy). Needs the CARRY body part. The target has to be at adjacent square to the creep or at the same square.
      * @param target The target object to be picked up.
      */
-    pickup(target: Resource): number;
+    pickup(target: Resource): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrBusy | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrNotInRange;
     /**
      * A ranged attack against another creep or structure. Needs the RANGED_ATTACK body part. If the target is inside a rampart, the rampart is attacked instead. The target has to be within 3 squares range of the creep.
      * @param target The target object to be attacked.
      */
-    rangedAttack(target: Creep | Spawn | Structure): number;
+    rangedAttack(target: Creep | Structure): TargetCreepReturn;
     /**
      * Heal another creep at a distance. It will restore the target creep’s damaged body parts function and increase the hits counter. Needs the HEAL body part. The target has to be within 3 squares range of the creep.
      * @param target The target creep object.
      */
-    rangedHeal(target: Creep): number;
+    rangedHeal(target: Creep): TargetCreepReturn;
     /**
      * A ranged attack against all hostile creeps or structures within 3 squares range. Needs the RANGED_ATTACK body part. The attack power depends on the range to each target. Friendly units are not affected.
      */
-    rangedMassAttack(): number;
+    rangedMassAttack(): StandardCreepReturn;
     /**
      * Repair a damaged structure using carried energy. Needs the WORK and CARRY body parts. The target has to be within 3 squares range of the creep.
      * @param target he target structure to be repaired.
      */
-    repair(target: Spawn | Structure): number;
+    repair(target: Structure): TargetCreepReturn | ReturnConstErrNotEnough;
     /**
      * Temporarily block a neutral controller from claiming by other players. Each tick, this command increases the counter of the period during which the controller is unavailable by 1 tick per each CLAIM body part. The maximum reservation period to maintain is 5,000 ticks. The target has to be at adjacent square to the creep....
      * @param target The target controller object to be reserved.
      * @return Result code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART
      */
-    reserveController(target: Controller): number;
+    reserveController(target: Controller): TargetCreepReturn;
     /**
      * Display a visual speech balloon above the creep with the specified message. The message will disappear after a few seconds. Useful for debugging purposes. Only the creep's owner can see the speech message.
      * @param message The message to be displayed. Maximum length is 10 characters.
      * @param set to 'true' to allow other players to see this message. Default is 'false'.
      */
-    say(message: string, toPublic?: boolean): number;
+    say(message: string, toPublic?: boolean): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrBusy;
     /**
      * Kill the creep immediately.
      */
-    suicide(): number;
+    suicide(): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrBusy;
     /**
      * Transfer resource from the creep to another object. The target has to be at adjacent square to the creep.
      * @param target The target object.
      * @param resourceType One of the RESOURCE_* constants
      * @param amount The amount of resources to be transferred. If omitted, all the available carried amount is used.
      */
-    transfer(target: Creep | Spawn | Structure, resourceType: string, amount?: number): number;
+    transfer(target: Creep | Structure, resourceType: ResourceConst, amount?: number): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrBusy | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrNotInRange | ReturnConstErrInvalidArgs;
     /**
      * Upgrade your controller to the next level using carried energy. Upgrading controllers raises your Global Control Level in parallel. Needs WORK and CARRY body parts. The target has to be at adjacent square to the creep. A fully upgraded level 8 controller can't be upgraded with the power over 15 energy units per tick regardless of creeps power. The cumulative effect of all the creeps performing upgradeController in the current tick is taken into account.
      * @param target The target controller object to be upgraded.
      */
-    upgradeController(target: Controller): number;
+    upgradeController(target: Controller): TargetCreepReturn | ReturnConstErrNotEnough;
     /**
      * Withdraw resources from a structure. The target has to be at adjacent square to the creep. Multiple creeps can withdraw from the same structure in the same tick. Your creeps can withdraw resources from hostile structures as well, in case if there is no hostile rampart on top of it.
      * @param target The target object.
      * @param resourceType The target One of the RESOURCE_* constants..
      * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
      */
-    withdraw(target: Structure, resourceType: string, amount?: number): number;
+    withdraw(target: Structure, resourceType: ResourceConst, amount?: number): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrBusy | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrNotInRange | ReturnConstErrInvalidArgs;
 }
 interface CreepConstructor extends _Constructor<Creep>, _ConstructorById<Creep> {
 }
@@ -605,7 +776,7 @@ interface Flag extends RoomObject {
     /**
      * Flag color. One of the following constants: COLOR_WHITE, COLOR_GREY, COLOR_RED, COLOR_PURPLE, COLOR_BLUE, COLOR_CYAN, COLOR_GREEN, COLOR_YELLOW, COLOR_ORANGE, COLOR_BROWN
      */
-    color: number;
+    color: ColorConst;
     /**
      * A shorthand to Memory.flags[flag.name]. You can use it for quick access the flag's specific memory data object.
      */
@@ -617,26 +788,26 @@ interface Flag extends RoomObject {
     /**
      * Flag secondary color. One of the COLOR_* constants.
      */
-    secondaryColor: number;
+    secondaryColor: ColorConst;
     /**
      * Remove the flag.
      * @returns Result Code: OK
      */
-    remove(): number;
+    remove(): ReturnConstOk;
     /**
      * Set new color of the flag.
      * @param color One of the following constants: COLOR_WHITE, COLOR_GREY, COLOR_RED, COLOR_PURPLE, COLOR_BLUE, COLOR_CYAN, COLOR_GREEN, COLOR_YELLOW, COLOR_ORANGE, COLOR_BROWN
      * @parma secondaryColor Secondary color of the flag. One of the COLOR_* constants.
      * @returns Result Code: OK, ERR_INVALID_ARGS
      */
-    setColor(color: number, secondaryColor?: number): number;
+    setColor(color: ColorConst, secondaryColor?: ColorConst): ReturnConstOk | ReturnConstErrInvalidArgs;
     /**
      * Set new position of the flag.
      * @param x The X position in the room.
      * @param y The Y position in the room.
      * @returns Result Code: OK, ERR_INVALID_TARGET
      */
-    setPosition(x: number, y: number): number;
+    setPosition(x: number, y: number): ReturnConstOk | ReturnConstErrInvalidTarget;
     /**
      * Set new position of the flag.
      * @param pos Can be a RoomPosition object or any object containing RoomPosition.
@@ -644,11 +815,11 @@ interface Flag extends RoomObject {
      */
     setPosition(pos: RoomPosition | {
         pos: RoomPosition;
-    }): number;
+    }): ReturnConstOk | ReturnConstErrInvalidTarget;
 }
 interface FlagConstructor extends _Constructor<Flag> {
-    new (name: string, color: number, secondaryColor: number, roomName: string, x: number, y: number): Flag;
-    (name: string, color: number, secondaryColor: number, roomName: string, x: number, y: number): Flag;
+    new (name: string, color: ColorConst, secondaryColor: ColorConst, roomName: string, x: number, y: number): Flag;
+    (name: string, color: ColorConst, secondaryColor: ColorConst, roomName: string, x: number, y: number): Flag;
 }
 declare const Flag: FlagConstructor;
 /**
@@ -741,15 +912,15 @@ interface CPU {
 /**
  * An array describing the creep’s body. Each element contains the following properties:
  */
-interface BodyPartDefinition {
+interface BodypartDefinition {
     /**
      * If the body part is boosted, this property specifies the mineral type which is used for boosting. One of the RESOURCE_* constants.
      */
-    boost: string;
+    boost: ResourceConst;
     /**
      * One of the body part types constants.
      */
-    type: string;
+    type: BodypartConst;
     /**
      * The remaining amount of hit points of this body part.
      */
@@ -764,16 +935,16 @@ interface ReservationDefinition {
 }
 interface StoreDefinition {
     [resource: string]: number | undefined;
-    energy?: number;
+    energy: number;
     power?: number;
 }
 interface LookAtResultWithPos {
     x: number;
     y: number;
-    type: string;
+    type: LookConst;
     constructionSite?: ConstructionSite;
     creep?: Creep;
-    terrain?: string;
+    terrain?: TerrainConst;
     structure?: Structure;
     flag?: Flag;
     energy?: Resource;
@@ -781,6 +952,7 @@ interface LookAtResultWithPos {
     source?: Source;
     mineral?: Mineral;
     resource?: Resource;
+    [key: string]: any;
 }
 interface LookAtResult {
     type: string;
@@ -791,9 +963,10 @@ interface LookAtResult {
     flag?: Flag;
     source?: Source;
     structure?: Structure;
-    terrain?: string;
+    terrain?: TerrainConst;
     mineral?: Mineral;
     resource?: Resource;
+    [key: string]: any;
 }
 interface LookAtResultMatrix {
     [coord: number]: LookAtResultMatrix | LookAtResult[];
@@ -873,12 +1046,29 @@ interface MoveToOpts {
      */
     noPathFinding?: boolean;
 }
+interface FindRouteOpts {
+    /**
+     * This callback accepts two arguments: function(roomName, fromRoomName). It can be used to calculate the cost of entering that
+     * room. You can use this to do things like prioritize your own rooms, or avoid some rooms. You can return a floating point cost
+     * or Infinity to block the room.
+     */
+    routeCallback?(roomName: string, fromRoomName: string): number;
+}
+interface RouteStep {
+    exit: FindConstExit;
+    room: string;
+}
 interface PathStep {
     x: number;
     dx: number;
     y: number;
     dy: number;
     direction: number;
+}
+declare type PathFinderGoal = RoomPosition | PathFinderGoalObject;
+interface PathFinderGoalObject {
+    pos: RoomPosition;
+    range?: number;
 }
 /**
  * An object with survival game info
@@ -904,6 +1094,7 @@ interface _ConstructorById<T> extends _Constructor<T> {
     new (id: string): T;
     (id: string): T;
 }
+declare type PathfindingAlgorithm = "astar" | "dijkstra";
 /**
  * A global object representing world map. Use it to navigate between rooms. The object is accessible via Game.map property.
  */
@@ -914,11 +1105,11 @@ interface GameMap {
      * @returns The exits information or null if the room not found.
      */
     describeExits(roomName: string): {
-        "1": string;
-        "3": string;
-        "5": string;
-        "7": string;
-    };
+        "1"?: string;
+        "3"?: string;
+        "5"?: string;
+        "7"?: string;
+    } | null;
     /**
      * Find the exit direction from the given room en route to another room.
      * @param fromRoom Start room name or room object.
@@ -928,21 +1119,14 @@ interface GameMap {
      * Or one of the following Result codes:
      * ERR_NO_PATH, ERR_INVALID_ARGS
      */
-    findExit(fromRoom: string | Room, toRoom: string | Room): string | number;
+    findExit(fromRoom: string | Room, toRoom: string | Room, opts?: FindRouteOpts): FindConstExit | ReturnConstErrNoPath | ReturnConstErrInvalidArgs;
     /**
      * Find route from the given room to another room.
      * @param fromRoom Start room name or room object.
      * @param toRoom Finish room name or room object.
      * @returns the route array or ERR_NO_PATH code
      */
-    findRoute(fromRoom: string | Room, toRoom: string | Room, opts?: {
-        routeCallback: {
-            (roomName: string, fromRoomName: string): any;
-        };
-    }): {
-        exit: string;
-        room: string;
-    }[] | number;
+    findRoute(fromRoom: string | Room, toRoom: string | Room, opts?: FindRouteOpts): RouteStep[] | ReturnConstErrNoPath;
     /**
      * Get the linear distance (in rooms) between two rooms. You can use this function to estimate the energy cost of
      * sending resources through terminals, or using observers and nukes.
@@ -960,12 +1144,12 @@ interface GameMap {
      * @param y Y position in the room.
      * @param roomName The room name.
      */
-    getTerrainAt(x: number, y: number, roomName: string): string;
+    getTerrainAt(x: number, y: number, roomName: string): TerrainConst;
     /**
      * Get terrain type at the specified room position. This method works for any room in the world even if you have no access to it.
      * @param pos The position object.
      */
-    getTerrainAt(pos: RoomPosition): string;
+    getTerrainAt(pos: RoomPosition): TerrainConst;
     /**
      * Check if the room with the given name is protected by temporary "newbie" walls.
      * @param roomName The room name.
@@ -1003,20 +1187,20 @@ interface Market {
     /**
      * Cancel a previously created order. The 5% fee is not returned.
      */
-    cancelOrder(orderId: string): number;
+    cancelOrder(orderId: string): ReturnConstOk | ReturnConstErrInvalidArgs;
     /**
      * Create a market order in your terminal. You will be charged price*amount*0.05 credits when the order is placed.
      * The maximum orders count is 20 per player. You can create an order at any time with any amount,
      * it will be automatically activated and deactivated depending on the resource/credits availability.
      */
-    createOrder(type: string, resourceType: string, price: number, totalAmount: number, roomName?: string): number;
+    createOrder(type: OrderConst, resourceType: ResourceConst | SubscriptionTokenConst, price: number, totalAmount: number, roomName?: string): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrNotEnough | ReturnConstErrFull | ReturnConstErrInvalidArgs;
     /**
      * Execute a trade deal from your Terminal to another player's Terminal using the specified buy/sell order.
      * Your Terminal will be charged energy units of transfer cost regardless of the order resource type.
      * You can use Game.market.calcTransactionCost method to estimate it.
      * When multiple players try to execute the same deal, the one with the shortest distance takes precedence.
      */
-    deal(orderId: string, amount: number, targetRoomName?: string): number;
+    deal(orderId: string, amount: number, targetRoomName?: string): ReturnConstOk | ReturnConstErrNotEnough | ReturnConstErrFull | ReturnConstErrInvalidArgs;
     /**
      * Get other players' orders currently active on the market.
      */
@@ -1025,35 +1209,59 @@ interface Market {
 interface Transaction {
     transactionId: string;
     time: number;
-    sender?: {
-        username: string;
-    };
-    recipient?: {
-        username: string;
-    };
-    resourceType: string;
+    sender?: Owner;
+    recipient?: Owner;
+    resourceType: ResourceConst | SubscriptionTokenConst;
     amount: number;
     from: string;
     to: string;
-    description: string;
+    description: string | null;
 }
 interface Order {
+    /**
+     * The unique order ID.
+     */
     id: string;
-    created: number;
+    /**
+     * Whether this order is active and visible to other players. An order can become non-active when the terminal
+     * doesn't have enough resources to sell or you are out of credits to buy.
+     */
     active?: boolean;
-    type: string;
-    resourceType: string;
+    /**
+     * The order creation time in game ticks.
+     */
+    created: number;
+    /**
+     * Either ORDER_SELL or ORDER_BUY.
+     */
+    type: OrderConst;
+    /**
+     * Either one of the RESOURCE_* constants or SUBSCRIPTION_TOKEN.
+     */
+    resourceType: ResourceConst | SubscriptionTokenConst;
+    /**
+     * The room where this order is placed.
+     */
     roomName?: string;
+    /**
+     * Currently available amount to trade.
+     */
     amount: number;
+    /**
+     * How many resources are left to trade via this order. When it becomes equal to zero, the order is removed.
+     */
     remainingAmount: number;
+    /**
+     * Initial order amount.
+     */
     totalAmount?: number;
     price: number;
 }
 interface OrderFilter {
     id?: string;
     created?: number;
-    type?: string;
-    resourceType?: string;
+    type?: OrderConst;
+    resourceType?: ResourceConst | SubscriptionTokenConst;
     roomName?: string;
     amount?: number;
     remainingAmount?: number;
@@ -1083,13 +1291,17 @@ interface Mineral extends RoomObject {
      */
     readonly prototype: Mineral;
     /**
+     * Room cannot be undefined for a Mineral.
+     */
+    room: Room;
+    /**
      * The remaining amount of resources.
      */
     mineralAmount: number;
     /**
      * The resource type, one of the RESOURCE_* constants.
      */
-    mineralType: string;
+    mineralType: ResourceConst;
     /**
      * A unique object identificator. You can use Game.getObjectById method to retrieve an object instance by its id.
      */
@@ -1107,6 +1319,10 @@ declare const Mineral: MineralConstructor;
  */
 interface Nuke extends RoomObject {
     readonly prototype: Nuke;
+    /**
+     * Room cannot be undefined for a Nuke.
+     */
+    room: Room;
     /**
      * A unique object identificator. You can use Game.getObjectById method to retrieve an object instance by its id.
      */
@@ -1140,27 +1356,7 @@ interface PathFinder {
      * @param goal goal A RoomPosition or an object containing a RoomPosition and range
      * @param opts An object containing additional pathfinding flags.
      */
-    search(origin: RoomPosition, goal: RoomPosition | {
-        pos: RoomPosition;
-        range: number;
-    }, opts?: PathFinderOpts): {
-        path: RoomPosition[];
-        ops: number;
-    };
-    /**
-     * Find an optimal path between origin and goal.
-     *
-     * @param origin The start position.
-     * @param goal an array of goals, the cheapest path found out of all the goals will be returned.
-     * @param opts An object containing additional pathfinding flags.
-     */
-    search(origin: RoomPosition, goal: RoomPosition[] | {
-        pos: RoomPosition;
-        range: number;
-    }[], opts?: PathFinderOpts): {
-        path: RoomPosition[];
-        ops: number;
-    };
+    search(origin: RoomPosition, goal: PathFinderGoal | PathFinderGoal[], opts?: PathFinderOpts): PathFinderReturn;
     /**
      * Specify whether to use this new experimental pathfinder in game objects methods.
      * This method should be invoked every tick. It affects the following methods behavior:
@@ -1169,6 +1365,24 @@ interface PathFinder {
      * @param isEnabled Whether to activate the new pathfinder or deactivate.
      */
     use(isEnabled: boolean): any;
+}
+interface PathFinderReturn {
+    /**
+     * An array of RoomPosition objects.
+     */
+    path: RoomPosition[];
+    /**
+     * Total number of operations performed before this path was calculated.
+     */
+    ops: number;
+    /**
+     * The total cost of the path as derived from `plainCost`, `swampCost` and any given CostMatrix instances.
+     */
+    cost: number;
+    /**
+     * If the pathfinder fails to find a complete path, this will be true. Note that `path` will still be populated with a partial path which represents the closest path it could find given the search parameters.
+     */
+    incomplete: boolean;
 }
 /**
  * An object containing additional pathfinding flags.
@@ -1266,6 +1480,10 @@ interface RawMemory {
 interface Resource extends RoomObject {
     readonly prototype: Resource;
     /**
+     * Room cannot be undefined for a Resource.
+     */
+    room: Room;
+    /**
      * The amount of resource units containing.
      */
     amount: number;
@@ -1276,7 +1494,7 @@ interface Resource extends RoomObject {
     /**
      * One of the `RESOURCE_*` constants.
      */
-    resourceType: string;
+    resourceType: ResourceConst;
 }
 interface ResourceConstructor {
     new (id: string): Resource;
@@ -1297,7 +1515,7 @@ interface RoomObject {
      * flag or a construction site and is placed in a room that is not visible
      * to you.
      */
-    room: Room;
+    room: Room | undefined;
 }
 interface RoomObjectConstructor extends _Constructor<RoomObject> {
     new (x: number, y: number, roomName: string): RoomObject;
@@ -1325,23 +1543,23 @@ interface RoomPosition {
      * Create new ConstructionSite at the specified location.
      * @param structureType One of the following constants: STRUCTURE_EXTENSION, STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_SPAWN, STRUCTURE_WALL, STRUCTURE_LINK
      */
-    createConstructionSite(structureType: string): number;
+    createConstructionSite(structureType: StructureConst): ReturnConstOk | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrInvalidArgs | ReturnConstErrRCL;
     /**
      * Create new Flag at the specified location.
      * @param name The name of a new flag. It should be unique, i.e. the Game.flags object should not contain another flag with the same name (hash key). If not defined, a random name will be generated.
      * @param color The color of a new flag. Should be one of the COLOR_* constants
      * @param secondaryColor The secondary color of a new flag. Should be one of the COLOR_* constants. The default value is equal to color.
      */
-    createFlag(name?: string, color?: number, secondaryColor?: number): number;
+    createFlag(name?: string, color?: ColorConst, secondaryColor?: ColorConst): string | ReturnConstErrNameExists | ReturnConstErrInvalidArgs;
     /**
      * Find an object with the shortest path from the given position. Uses A* search algorithm and Dijkstra's algorithm.
      * @param type See Room.find
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      */
-    findClosestByPath<T>(type: number, opts?: FindPathOpts & {
+    findClosestByPath<T>(type: FindConst, opts?: FindPathOpts & {
         filter?: any | string;
-        algorithm?: string;
-    }): T;
+        algorithm?: PathfindingAlgorithm;
+    }): T | null;
     /**
      * Find an object with the shortest path from the given position. Uses A* search algorithm and Dijkstra's algorithm.
      * @param objects An array of room's objects or RoomPosition objects that the search should be executed against.
@@ -1349,16 +1567,16 @@ interface RoomPosition {
      */
     findClosestByPath<T>(objects: T[] | RoomPosition[], opts?: FindPathOpts & {
         filter?: any | string;
-        algorithm?: string;
-    }): T;
+        algorithm?: PathfindingAlgorithm;
+    }): T | null;
     /**
      * Find an object with the shortest linear distance from the given position.
      * @param type See Room.find.
      * @param opts
      */
-    findClosestByRange<T>(type: number, opts?: {
+    findClosestByRange<T>(type: FindConst, opts?: {
         filter: any | string;
-    }): T;
+    }): T | null;
     /**
      * Find an object with the shortest linear distance from the given position.
      * @param objects An array of room's objects or RoomPosition objects that the search should be executed against.
@@ -1366,14 +1584,14 @@ interface RoomPosition {
      */
     findClosestByRange<T>(objects: T[] | RoomPosition[], opts?: {
         filter: any | string;
-    }): T;
+    }): T | null;
     /**
      * Find all objects in the specified linear range.
      * @param type See Room.find.
      * @param range The range distance.
      * @param opts See Room.find.
      */
-    findInRange<T>(type: number, range: number, opts?: {
+    findInRange<T>(type: FindConst, range: number, opts?: {
         filter?: any | string;
     }): T[];
     /**
@@ -1405,14 +1623,14 @@ interface RoomPosition {
      * @param x X position in the room.
      * @param y Y position in the room.
      */
-    getDirectionTo(x: number, y: number): number;
+    getDirectionTo(x: number, y: number): DirConst;
     /**
      * Get linear direction to the specified position.
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
      */
     getDirectionTo(target: RoomPosition | {
         pos: RoomPosition;
-    }): number;
+    }): DirConst;
     /**
      * Get linear range to the specified position.
      * @param x X position in the room.
@@ -1428,10 +1646,19 @@ interface RoomPosition {
     }): number;
     /**
      * Check whether this position is in the given range of another position.
-     * @param toPos The target position.
+     * @param x X position in the room.
+     * @param y Y position in the room.
      * @param range The range distance.
      */
-    inRangeTo(toPos: RoomPosition, range: number): boolean;
+    inRangeTo(x: number, y: number, range: number): boolean;
+    /**
+     * Check whether this position is in the given range of another position.
+     * @param target The target position.
+     * @param range The range distance.
+     */
+    inRangeTo(target: RoomPosition | {
+        pos: RoomPosition;
+    }, range: number): boolean;
     /**
      * Check whether this position is the same as the specified position.
      * @param x X position in the room.
@@ -1466,7 +1693,7 @@ interface RoomPosition {
      * Get an object with the given type at the specified room position.
      * @param type One of the following string constants: constructionSite, creep, exit, flag, resource, source, structure, terrain
      */
-    lookFor<T>(type: string): T[];
+    lookFor<T>(type: LookConst): T[];
 }
 interface RoomPositionConstructor extends _Constructor<RoomPosition> {
     /**
@@ -1504,7 +1731,7 @@ interface Room {
      * One of the following constants:
      * MODE_SIMULATION, MODE_SURVIVAL, MODE_WORLD, MODE_ARENA
      */
-    mode: string;
+    mode: ModeConst;
     /**
      * The name of the room.
      */
@@ -1528,7 +1755,7 @@ interface Room {
      * @param structureType One of the following constants: STRUCTURE_EXTENSION, STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_SPAWN, STRUCTURE_WALL, STRUCTURE_LINK
      * @returns Result Code: OK, ERR_INVALID_TARGET, ERR_INVALID_ARGS, ERR_RCL_NOT_ENOUGH
      */
-    createConstructionSite(x: number, y: number, structureType: string): number;
+    createConstructionSite(x: number, y: number, structureType: StructureConst): ReturnConstOk | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrInvalidArgs | ReturnConstErrRCL;
     /**
      * Create new ConstructionSite at the specified location.
      * @param pos Can be a RoomPosition object or any object containing RoomPosition.
@@ -1537,7 +1764,7 @@ interface Room {
      */
     createConstructionSite(pos: RoomPosition | {
         pos: RoomPosition;
-    }, structureType: string): number;
+    }, structureType: StructureConst): ReturnConstOk | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrInvalidArgs | ReturnConstErrRCL;
     /**
      * Create new Flag at the specified location.
      * @param x The X position.
@@ -1546,7 +1773,7 @@ interface Room {
      * @param color The color of a new flag. Should be one of the COLOR_* constants. The default value is COLOR_WHITE.
      * @param secondaryColor The secondary color of a new flag. Should be one of the COLOR_* constants. The default value is equal to color.
      */
-    createFlag(x: number, y: number, name?: string, color?: number, secondaryColor?: number): number;
+    createFlag(x: number, y: number, name?: string, color?: ColorConst, secondaryColor?: ColorConst): string | ReturnConstErrNameExists | ReturnConstErrInvalidArgs;
     /**
      * Create new Flag at the specified location.
      * @param pos Can be a RoomPosition object or any object containing RoomPosition.
@@ -1556,14 +1783,14 @@ interface Room {
      */
     createFlag(pos: RoomPosition | {
         pos: RoomPosition;
-    }, name?: string, color?: number, secondaryColor?: number): number;
+    }, name?: string, color?: ColorConst, secondaryColor?: ColorConst): string | ReturnConstErrNameExists | ReturnConstErrInvalidArgs;
     /**
      * Find all objects of the specified type in the room.
      * @param type One of the following constants:FIND_CREEPS, FIND_MY_CREEPS, FIND_HOSTILE_CREEPS, FIND_MY_SPAWNS, FIND_HOSTILE_SPAWNS, FIND_SOURCES, FIND_SOURCES_ACTIVE, FIND_DROPPED_RESOURCES, FIND_DROPPED_ENERGY, FIND_STRUCTURES, FIND_MY_STRUCTURES, FIND_HOSTILE_STRUCTURES, FIND_FLAGS, FIND_CONSTRUCTION_SITES, FIND_EXIT_TOP, FIND_EXIT_RIGHT, FIND_EXIT_BOTTOM, FIND_EXIT_LEFT, FIND_EXIT
      * @param opts An object with additional options
      * @returns An array with the objects found.
      */
-    find<T>(type: number, opts?: {
+    find<T>(type: FindConst, opts?: {
         filter: Object | Function | string;
     }): T[];
     /**
@@ -1572,7 +1799,7 @@ interface Room {
      * @returns The room direction constant, one of the following: FIND_EXIT_TOP, FIND_EXIT_RIGHT, FIND_EXIT_BOTTOM, FIND_EXIT_LEFT
      * Or one of the following error codes: ERR_NO_PATH, ERR_INVALID_ARGS
      */
-    findExitTo(room: string | Room): number;
+    findExitTo(room: string | Room): FindConstExit | ReturnConstErrNoPath | ReturnConstErrInvalidArgs;
     /**
      * Find an optimal path inside the room between fromPos and toPos using A* search algorithm.
      * @param fromPos The start position.
@@ -1619,14 +1846,14 @@ interface Room {
      * @param y The Y position.
      * @returns An array of objects of the given type at the specified position if found.
      */
-    lookForAt<T>(type: string, x: number, y: number): T[];
+    lookForAt<T>(type: LookConst, x: number, y: number): T[];
     /**
      * Get an object with the given type at the specified room position.
      * @param type One of the following string constants: constructionSite, creep, energy, exit, flag, source, structure, terrain
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
      * @returns An array of objects of the given type at the specified position if found.
      */
-    lookForAt<T>(type: string, target: RoomPosition | {
+    lookForAt<T>(type: LookConst, target: RoomPosition | {
         pos: RoomPosition;
     }): T[];
     /**
@@ -1638,11 +1865,41 @@ interface Room {
      * @param right The right X boundary of the area.
      * @returns An object with all the objects of the given type in the specified area
      */
-    lookForAtArea(type: string, top: number, left: number, bottom: number, right: number, asArray?: boolean): LookAtResultMatrix | LookAtResultWithPos[];
+    lookForAtArea(type: LookConst, top: number, left: number, bottom: number, right: number, asArray: true): LookAtResultWithPos[];
+    /**
+     * Get the list of objects with the given type at the specified room area. This method is more CPU efficient in comparison to multiple lookForAt calls.
+     * @param type One of the following string constants: constructionSite, creep, energy, exit, flag, source, structure, terrain
+     * @param top The top Y boundary of the area.
+     * @param left The left X boundary of the area.
+     * @param bottom The bottom Y boundary of the area.
+     * @param right The right X boundary of the area.
+     * @returns An object with all the objects of the given type in the specified area
+     */
+    lookForAtArea(type: LookConst, top: number, left: number, bottom: number, right: number, asArray?: false): LookAtResultMatrix;
+    /**
+     * Get the list of objects with the given type at the specified room area. This method is more CPU efficient in comparison to multiple lookForAt calls.
+     * @param type One of the following string constants: constructionSite, creep, energy, exit, flag, source, structure, terrain
+     * @param top The top Y boundary of the area.
+     * @param left The left X boundary of the area.
+     * @param bottom The bottom Y boundary of the area.
+     * @param right The right X boundary of the area.
+     * @returns An object with all the objects of the given type in the specified area
+     */
+    lookForAtArea(type: LookConst, top: number, left: number, bottom: number, right: number, asArray?: boolean): LookAtResultMatrix | LookAtResultWithPos[];
 }
 interface RoomConstructor {
     new (id: string): Room;
+    /**
+     * Serialize a path array into a short string representation, which is suitable to store in memory.
+     * @param path A path array retrieved from Room.findPath.
+     * @returns A serialized string form of the given path.
+     */
     serializePath(path: PathStep[]): string;
+    /**
+     * Deserialize a short string path representation into an array form.
+     * @param path A serialized path string.
+     * @returns A path array.
+     */
     deserializePath(path: string): PathStep[];
 }
 declare const Room: RoomConstructor;
@@ -1654,6 +1911,10 @@ interface Source extends RoomObject {
      * The prototype is stored in the Source.prototype global object. You can use it to extend game objects behaviour globally:
      */
     readonly prototype: Source;
+    /**
+     * Room cannot be undefined for a Source.
+     */
+    room: Room;
     /**
      * The remaining amount of energy.
      */
@@ -1688,45 +1949,17 @@ interface StructureSpawn extends OwnedStructure {
      */
     energyCapacity: number;
     /**
-     * The current amount of hit points of the spawn.
-     */
-    hits: number;
-    /**
-     * The maximum amount of hit points of the spawn.
-     */
-    hitsMax: number;
-    /**
-     * A unique object identificator. You can use Game.getObjectById method to retrieve an object instance by its id.
-     */
-    id: string;
-    /**
      * A shorthand to Memory.spawns[spawn.name]. You can use it for quick access the spawn’s specific memory data object.
      */
     memory: any;
-    /**
-     * Whether it is your spawn or foe.
-     */
-    my: boolean;
     /**
      * Spawn’s name. You choose the name upon creating a new spawn, and it cannot be changed later. This name is a hash key to access the spawn via the Game.spawns object.
      */
     name: string;
     /**
-     * An object with the spawn’s owner info containing the following properties: username
-     */
-    owner: Owner;
-    /**
-     * An object representing the position of this spawn in a room.
-     */
-    pos: RoomPosition;
-    /**
-     * The link to the Room object of this spawn.
-     */
-    room: Room;
-    /**
      * Always equal to ‘spawn’.
      */
-    structureType: string;
+    structureType: StructureConstSpawn;
     /**
      * If the spawn is in process of spawning a new creep, this object will contain the new creep’s information, or null otherwise.
      * @param name The name of a new creep.
@@ -1737,13 +1970,13 @@ interface StructureSpawn extends OwnedStructure {
         name: string;
         needTime: number;
         remainingTime: number;
-    };
+    } | null;
     /**
      * Check if a creep can be created.
      * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of these constants: WORK, MOVE, CARRY, ATTACK, RANGED_ATTACK, HEAL, TOUGH, CLAIM
      * @param name The name of a new creep. It should be unique creep name, i.e. the Game.creeps object should not contain another creep with the same name (hash key). If not defined, a random name will be generated.
      */
-    canCreateCreep(body: string[], name?: string): number;
+    canCreateCreep(body: BodypartConst[], name?: string): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrNameExists | ReturnConstErrBusy | ReturnConstErrNotEnough | ReturnConstErrInvalidArgs | ReturnConstErrRCL;
     /**
      * Start the creep spawning process.
      * The name of a new creep or one of these error codes
@@ -1757,36 +1990,25 @@ interface StructureSpawn extends OwnedStructure {
      * @param name The name of a new creep. It should be unique creep name, i.e. the Game.creeps object should not contain another creep with the same name (hash key). If not defined, a random name will be generated.
      * @param memory The memory of a new creep. If provided, it will be immediately stored into Memory.creeps[name].
      */
-    createCreep(body: string[], name?: string, memory?: any): number | string;
-    /**
-     * Destroy this spawn immediately.
-     */
-    destroy(): number;
-    /**
-     * Check whether this structure can be used. If the room controller level is not enough, then this method will return false, and the structure will be highlighted with red in the game.
-     */
-    isActive(): boolean;
-    /**
-     * Toggle auto notification when the spawn is under attack. The notification will be sent to your account email. Turned on by default.
-     * @param enabled Whether to enable notification or disable.
-     */
-    notifyWhenAttacked(enabled: boolean): number;
-    /**
-     * Increase the remaining time to live of the target creep. The target should be at adjacent square. The spawn should not be busy with the spawning process. Each execution increases the creep's timer by amount of ticks according to this formula: floor(500/body_size). Energy required for each execution is determined using this formula: ceil(creep_cost/3/body_size).
-     * @param target The target creep object.
-     */
-    renewCreep(target: Creep): number;
+    createCreep(body: BodypartConst[], name?: string, memory?: any): string | ReturnConstErrNotOwner | ReturnConstErrNameExists | ReturnConstErrBusy | ReturnConstErrNotEnough | ReturnConstErrInvalidArgs | ReturnConstErrRCL;
     /**
      * Kill the creep and drop up to 100% of resources spent on its spawning and boosting depending on remaining life time. The target should be at adjacent square.
      * @param target The target creep object.
      */
-    recycleCreep(target: Creep): number;
+    recycleCreep(target: Creep): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrInvalidTarget | ReturnConstErrNotInRange;
     /**
+     * Increase the remaining time to live of the target creep. The target should be at adjacent square. The spawn should not be busy with the spawning process. Each execution increases the creep's timer by amount of ticks according to this formula: floor(500/body_size). Energy required for each execution is determined using this formula: ceil(creep_cost/3/body_size).
+     * @param target The target creep object.
+     */
+    renewCreep(target: Creep): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrBusy | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrNotInRange;
+    /**
+     * DEPRECATED: Please use Creep.withdraw instead.
      * Transfer the energy from the spawn to a creep.
      * @param target The creep object which energy should be transferred to.
      * @param amount The amount of energy to be transferred. If omitted, all the remaining amount of energy will be used.
+     * @deprecated
      */
-    transferEnergy(target: Creep, amount?: number): number;
+    transferEnergy(target: Creep, amount?: number): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrNotInRange;
 }
 interface StructureSpawnConstructor extends _Constructor<StructureSpawn>, _ConstructorById<StructureSpawn> {
 }
@@ -1794,8 +2016,13 @@ declare const StructureSpawn: StructureSpawnConstructor;
 /**
  * Parent object for structure classes
  */
+declare type TransferEnergyReturn = ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrNotInRange;
 interface Structure extends RoomObject {
     readonly prototype: Structure;
+    /**
+     * Room cannot be undefined for a Structure.
+     */
+    room: Room;
     /**
      * The current amount of hit points of the structure.
      */
@@ -1811,11 +2038,11 @@ interface Structure extends RoomObject {
     /**
      * One of the STRUCTURE_* constants.
      */
-    structureType: string;
+    structureType: StructureConst;
     /**
      * Destroy this structure immediately.
      */
-    destroy(): number;
+    destroy(): ReturnConstOk | ReturnConstErrNotOwner;
     /**
      * Check whether this structure can be used. If the room controller level is not enough, then this method will return false, and the structure will be highlighted with red in the game.
      */
@@ -1824,7 +2051,7 @@ interface Structure extends RoomObject {
      * Toggle auto notification when the structure is under attack. The notification will be sent to your account email. Turned on by default.
      * @param enabled Whether to enable notification or disable.
      */
-    notifyWhenAttacked(enabled: boolean): number;
+    notifyWhenAttacked(enabled: boolean): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrInvalidArgs;
 }
 interface StructureConstructor extends _Constructor<Structure>, _ConstructorById<Structure> {
 }
@@ -1854,6 +2081,7 @@ declare const OwnedStructure: OwnedStructureConstructor;
  */
 interface StructureController extends OwnedStructure {
     readonly prototype: StructureController;
+    structureType: StructureConstContainer;
     /**
      * Current controller level, from 0 to 8.
      */
@@ -1869,7 +2097,7 @@ interface StructureController extends OwnedStructure {
     /**
      * An object with the controller reservation info if present: username, ticksToEnd
      */
-    reservation: ReservationDefinition;
+    reservation?: ReservationDefinition;
     /**
      * The amount of game ticks when this controller will lose one level. This timer can be reset by using Creep.upgradeController.
      */
@@ -1902,11 +2130,13 @@ interface StructureExtension extends OwnedStructure {
      */
     energyCapacity: number;
     /**
+     * DEPRECATED: Please use Creep.withdraw instead.
      * Transfer the energy from the extension to a creep.
      * @param target The creep object which energy should be transferred to.
      * @param amount The amount of energy to be transferred. If omitted, all the remaining amount of energy will be used.
+     * @deprecated
      */
-    transferEnergy(target: Creep, amount?: number): number;
+    transferEnergy(target: Creep, amount?: number): TransferEnergyReturn;
 }
 interface StructureExtensionConstructor extends _Constructor<StructureExtension>, _ConstructorById<StructureExtension> {
 }
@@ -1916,6 +2146,7 @@ declare const StructureExtension: StructureExtensionConstructor;
  */
 interface StructureLink extends OwnedStructure {
     readonly prototype: StructureLink;
+    structureType: StructureConstLink;
     /**
      * The amount of game ticks the link has to wait until the next transfer is possible.
      */
@@ -1933,7 +2164,7 @@ interface StructureLink extends OwnedStructure {
      * @param target The target object.
      * @param amount The amount of energy to be transferred. If omitted, all the available energy is used.
      */
-    transferEnergy(target: Creep | StructureLink, amount?: number): number;
+    transferEnergy(target: Creep | StructureLink, amount?: number): TransferEnergyReturn | ReturnConstErrInvalidArgs | ReturnConstErrTired | ReturnConstErrRCL;
 }
 interface StructureLinkConstructor extends _Constructor<StructureLink>, _ConstructorById<StructureLink> {
 }
@@ -1944,6 +2175,7 @@ declare const StructureLink: StructureLinkConstructor;
  */
 interface StructureKeeperLair extends OwnedStructure {
     readonly prototype: StructureKeeperLair;
+    structureType: StructureConstKeeperLair;
     /**
      * Time to spawning of the next Source Keeper.
      */
@@ -1957,11 +2189,12 @@ declare const StructureKeeperLair: StructureKeeperLairConstructor;
  */
 interface StructureObserver extends OwnedStructure {
     readonly prototype: StructureObserver;
+    structureType: StructureConstObserver;
     /**
      * Provide visibility into a distant room from your script. The target room object will be available on the next tick. The maximum range is 5 rooms.
      * @param roomName
      */
-    observeRoom(roomName: string): number;
+    observeRoom(roomName: string): ReturnConstOk | ReturnConstErrInvalidArgs | ReturnConstErrRCL;
 }
 interface StructureObserverConstructor extends _Constructor<StructureObserver>, _ConstructorById<StructureObserver> {
 }
@@ -1971,6 +2204,7 @@ declare const StructureObserver: StructureObserverConstructor;
  */
 interface StructurePowerBank extends OwnedStructure {
     readonly prototype: StructurePowerBank;
+    structureType: StructureConstPowerBank;
     /**
      * The amount of power containing.
      */
@@ -1989,6 +2223,7 @@ declare const StructurePowerBank: StructurePowerBankConstructor;
  */
 interface StructurePowerSpawn extends OwnedStructure {
     readonly prototype: StructurePowerSpawn;
+    structureType: StructureConstPowerSpawn;
     /**
      * The amount of energy containing in this structure.
      */
@@ -2013,13 +2248,15 @@ interface StructurePowerSpawn extends OwnedStructure {
     /**
      * Register power resource units into your account. Registered power allows to develop power creeps skills. Consumes 1 power resource unit and 50 energy resource units.
      */
-    processPower(): number;
+    processPower(): ReturnConstOk | ReturnConstErrNotEnough | ReturnConstErrRCL;
     /**
+     * DEPRECATED: Please use Creep.withdraw instead.
      * Transfer the energy from this structure to a creep.
      * @param target The creep object which energy should be transferred to.
      * @param amount The amount of energy to be transferred. If omitted, all the remaining amount of energy will be used.
+     * @deprecated
      */
-    transferEnergy(target: Creep, amount?: number): number;
+    transferEnergy(target: Creep, amount?: number): TransferEnergyReturn;
 }
 interface StructurePowerSpawnConstructor extends _Constructor<StructurePowerSpawn>, _ConstructorById<StructurePowerSpawn> {
 }
@@ -2030,6 +2267,7 @@ declare const StructurePowerSpawn: StructurePowerSpawnConstructor;
  */
 interface StructureRampart extends OwnedStructure {
     readonly prototype: StructureRampart;
+    structureType: StructureConstRampart;
     /**
      * The amount of game ticks when this rampart will lose some hit points.
      */
@@ -2042,7 +2280,7 @@ interface StructureRampart extends OwnedStructure {
      * Make this rampart public to allow other players' creeps to pass through.
      * @param isPublic Whether this rampart should be public or non-public
      */
-    setPublic(isPublic: boolean): any;
+    setPublic(isPublic: boolean): ReturnConstOk | ReturnConstErrNotOwner;
 }
 interface StructureRampartConstructor extends _Constructor<StructureRampart>, _ConstructorById<StructureRampart> {
 }
@@ -2053,6 +2291,7 @@ declare const StructureRampart: StructureRampartConstructor;
  */
 interface StructureRoad extends Structure {
     readonly prototype: StructureRoad;
+    structureType: StructureConstRoad;
     /**
      * The amount of game ticks when this road will lose some hit points.
      */
@@ -2067,6 +2306,7 @@ declare const StructureRoad: StructureRoadConstructor;
  */
 interface StructureStorage extends OwnedStructure {
     readonly prototype: StructureStorage;
+    structureType: StructureConstStorage;
     /**
      * An object with the storage contents.
      */
@@ -2076,19 +2316,14 @@ interface StructureStorage extends OwnedStructure {
      */
     storeCapacity: number;
     /**
+     * DEPRECATED: Please use Creep.withdraw instead.
      * Transfer resource from this storage to a creep. The target has to be at adjacent square.
      * @param target The target object.
      * @param resourceType One of the RESOURCE_* constants.
      * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
-     */
-    transfer(target: Creep, resourceType: string, amount?: number): number;
-    /**
-     * An alias for storage.transfer(target, RESOURCE_ENERGY, amount). This method is deprecated.
-     * @param target The target object.
-     * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
      * @deprecated
      */
-    transferEnergy(target: Creep, amount?: number): number;
+    transfer(target: Creep, resourceType: ResourceConst, amount?: number): TransferEnergyReturn | ReturnConstErrInvalidArgs;
 }
 interface StructureStorageConstructor extends _Constructor<StructureStorage>, _ConstructorById<StructureStorage> {
 }
@@ -2100,6 +2335,7 @@ declare const StructureStorage: StructureStorageConstructor;
  */
 interface StructureTower extends OwnedStructure {
     readonly prototype: StructureTower;
+    structureType: StructureConstTower;
     /**
      * The amount of energy containing in this structure.
      */
@@ -2112,23 +2348,25 @@ interface StructureTower extends OwnedStructure {
      * Remotely attack any creep in the room. Consumes 10 energy units per tick. Attack power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
      * @param target The target creep.
      */
-    attack(target: Creep): number;
+    attack(target: Creep): ReturnConstOk | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrRCL;
     /**
      * Remotely heal any creep in the room. Consumes 10 energy units per tick. Heal power depends on the distance to the target: from 400 hits at range 10 to 200 hits at range 40.
      * @param target The target creep.
      */
-    heal(target: Creep): number;
+    heal(target: Creep): ReturnConstOk | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrRCL;
     /**
      * Remotely repair any structure in the room. Consumes 10 energy units per tick. Repair power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
      * @param target The target structure.
      */
-    repair(target: Spawn | Structure): number;
+    repair(target: Structure): ReturnConstOk | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrRCL;
     /**
-     *
+     * DEPRECATED: Please use Creep.withdraw instead.
+     * Transfer the energy from this structure to a creep.
      * @param target The creep object which energy should be transferred to.
      * @param amount The amount of energy to be transferred. If omitted, all the remaining amount of energy will be used.
+     * @deprecated
      */
-    transferEnergy(target: Creep, amount?: number): number;
+    transferEnergy(target: Creep, amount?: number): TransferEnergyReturn;
 }
 interface StructureTowerConstructor extends _Constructor<StructureTower>, _ConstructorById<StructureTower> {
 }
@@ -2138,6 +2376,7 @@ declare const StructureTower: StructureTowerConstructor;
  */
 interface StructureWall extends Structure {
     readonly prototype: StructureWall;
+    structureType: StructureConstWall;
     /**
      * The amount of game ticks when the wall will disappear (only for automatically placed border walls at the start of the game).
      */
@@ -2151,6 +2390,7 @@ declare const StructureWall: StructureWallConstructor;
  */
 interface StructureExtractor extends OwnedStructure {
     readonly prototype: StructureExtractor;
+    structureType: StructureConstExtractor;
 }
 interface StructureExtractorConstructor extends _Constructor<StructureExtractor>, _ConstructorById<StructureExtractor> {
 }
@@ -2160,6 +2400,7 @@ declare const StructureExtractor: StructureExtractorConstructor;
  */
 interface StructureLab extends OwnedStructure {
     readonly prototype: StructureLab;
+    structureType: StructureConstLab;
     /**
      * The amount of game ticks the lab has to wait until the next reaction is possible.
      */
@@ -2179,7 +2420,7 @@ interface StructureLab extends OwnedStructure {
     /**
      * The type of minerals containing in the lab. Labs can contain only one mineral type at the same time.
      */
-    mineralType: string;
+    mineralType: ResourceConst;
     /**
      * The total amount of minerals the lab can contain.
      */
@@ -2189,20 +2430,22 @@ interface StructureLab extends OwnedStructure {
      * @param creep The target creep.
      * @param bodyPartsCount The number of body parts of the corresponding type to be boosted. Body parts are always counted left-to-right for TOUGH, and right-to-left for other types. If undefined, all the eligible body parts are boosted.
      */
-    boostCreep(creep: Creep, bodyPartsCount?: number): number;
+    boostCreep(creep: Creep, bodyPartsCount?: number): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrNotFound | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrNotInRange;
     /**
      * Produce mineral compounds using reagents from two another labs. Each lab has to be within 2 squares range. The same input labs can be used by many output labs
      * @param lab1 The first source lab.
      * @param lab2 The second source lab.
      */
-    runReaction(lab1: StructureLab, lab2: StructureLab): number;
+    runReaction(lab1: StructureLab, lab2: StructureLab): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrNotInRange | ReturnConstErrInvalidArgs | ReturnConstErrTired;
     /**
+     * DEPRECATED: Please use Creep.withdraw instead.
      * Transfer resource from this structure to a creep. The target has to be at adjacent square.
      * @param target The target object.
      * @param resourceType One of the RESOURCE_* constants.
      * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
+     * @deprecated
      */
-    transfer(target: Creep, resourceType: string, amount?: number): number;
+    transfer(target: Creep, resourceType: ResourceConst, amount?: number): TransferEnergyReturn | ReturnConstErrInvalidArgs;
 }
 interface StructureLabConstructor extends _Constructor<StructureLab>, _ConstructorById<StructureLab> {
 }
@@ -2212,10 +2455,11 @@ declare const StructureLab: StructureLabConstructor;
  */
 interface StructureTerminal extends OwnedStructure {
     readonly prototype: StructureTerminal;
+    structureType: StructureConstTerminal;
     /**
      * An object with the storage contents. Each object key is one of the RESOURCE_* constants, values are resources amounts.
      */
-    store: any;
+    store: StoreDefinition;
     /**
      * The total amount of resources the storage can contain.
      */
@@ -2227,14 +2471,16 @@ interface StructureTerminal extends OwnedStructure {
      * @param destination The name of the target room. You don't have to gain visibility in this room.
      * @param description The description of the transaction. It is visible to the recipient. The maximum length is 100 characters.
      */
-    send(resourceType: string, amount: number, destination: string, description?: string): number;
+    send(resourceType: ResourceConst, amount: number, destination: string, description?: string): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrNotEnough | ReturnConstErrInvalidArgs;
     /**
+     * DEPRECATED: Please use Creep.withdraw instead.
      * Transfer resource from this terminal to a creep. The target has to be at adjacent square.
      * @param target The target object.
      * @param resourceType One of the RESOURCE_* constants.
      * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
+     * @deprecated
      */
-    transfer(target: Creep, resourceType: String, amount?: number): number;
+    transfer(target: Creep, resourceType: ResourceConst, amount?: number): TransferEnergyReturn | ReturnConstErrInvalidArgs;
 }
 interface StructureTerminalConstructor extends _Constructor<StructureTerminal>, _ConstructorById<StructureTerminal> {
 }
@@ -2244,22 +2490,25 @@ declare const StructureTerminal: StructureTerminalConstructor;
  */
 interface StructureContainer extends Structure {
     readonly prototype: StructureContainer;
+    structureType: StructureConstContainer;
     /**
      * An object with the structure contents. Each object key is one of the RESOURCE_* constants, values are resources
      * amounts. Use _.sum(structure.store) to get the total amount of contents
      */
-    store: any;
+    store: StoreDefinition;
     /**
      * The total amount of resources the structure can contain.
      */
     storeCapacity: number;
     /**
+     * DEPRECATED: Please use Creep.withdraw instead.
      * Transfer resource from this structure to a creep. The target has to be at adjacent square.
      * @param target The target object.
      * @param resourceType One of the RESOURCE_* constants.
      * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
+     * @deprecated
      */
-    transfer(target: Creep, resourceType: string, amount?: number): number;
+    transfer(target: Creep, resourceType: ResourceConst, amount?: number): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrNotInRange | ReturnConstErrInvalidArgs;
 }
 interface StructureContainerConstructor extends _Constructor<StructureContainer>, _ConstructorById<StructureContainer> {
 }
@@ -2273,6 +2522,7 @@ declare const StructureContainer: StructureContainerConstructor;
  */
 interface StructureNuker extends OwnedStructure {
     readonly prototype: StructureNuker;
+    structureType: StructureConstNuker;
     /**
      * The amount of energy contained in this structure.
      */
@@ -2297,7 +2547,7 @@ interface StructureNuker extends OwnedStructure {
      * Launch a nuke to the specified position.
      * @param pos The target room position.
      */
-    launchNuke(pos: RoomPosition): number;
+    launchNuke(pos: RoomPosition): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrNotInRange | ReturnConstErrTired | ReturnConstErrRCL;
 }
 interface StructureNukerConstructor extends _Constructor<StructureNuker>, _ConstructorById<StructureNuker> {
 }
@@ -2309,6 +2559,7 @@ declare const StructureNuker: StructureNukerConstructor;
  */
 interface StructurePortal extends Structure {
     readonly prototype: StructurePortal;
+    structureType: StructureConstPortal;
     /**
      * The position object in the destination room.
      */
@@ -2316,7 +2567,7 @@ interface StructurePortal extends Structure {
     /**
      * The amount of game ticks when the portal disappears, or undefined when the portal is stable.
      */
-    ticksToDecay: number;
+    ticksToDecay: number | undefined;
 }
 interface StructurePortalConstructor extends _Constructor<StructurePortal>, _ConstructorById<StructurePortal> {
 }

--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -379,8 +379,9 @@ declare type Rampart = StructureRampart;
 declare type Terminal = StructureTerminal;
 declare type Container = StructureContainer;
 declare type Tower = StructureTower;
+declare type Spawn = StructureSpawn;
+declare const Spawn: StructureSpawnConstructor;
 interface Storage extends StructureStorage {
-    readonly prototype: StructureStorage;
 }
 /**
  * Creeps are your units. Creeps can move, harvest energy, construct structures, attack another creeps, and perform other actions. Each creep consists of up to 50 body parts with the following possible types:
@@ -1788,10 +1789,6 @@ interface StructureSpawn extends OwnedStructure {
 interface StructureSpawnConstructor extends _Constructor<StructureSpawn>, _ConstructorById<StructureSpawn> {
 }
 declare const StructureSpawn: StructureSpawnConstructor;
-interface Spawn extends StructureSpawn {
-    readonly prototype: StructureSpawn;
-}
-declare const Spawn: StructureSpawnConstructor;
 /**
  * Parent object for structure classes
  */

--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -329,7 +329,7 @@ declare var ORDER_BUY: string;
 /**
  * A site of a structure which is currently under construction.
  */
-declare class ConstructionSite extends RoomObject {
+interface ConstructionSite extends RoomObject {
     /**
      * A unique object identificator. You can use Game.getObjectById method to retrieve an object instance by its id.
      */
@@ -360,6 +360,10 @@ declare class ConstructionSite extends RoomObject {
      */
     remove(): number;
 }
+interface ConstructionSiteConstructor {
+    new (id: string): ConstructionSite;
+}
+declare const ConstructionSite: ConstructionSiteConstructor;
 declare var Memory: Memory;
 declare var Game: Game;
 declare var PathFinder: PathFinder;
@@ -380,7 +384,7 @@ interface Storage extends StructureStorage {
 /**
  * Creeps are your units. Creeps can move, harvest energy, construct structures, attack another creeps, and perform other actions. Each creep consists of up to 50 body parts with the following possible types:
  */
-declare class Creep extends RoomObject {
+interface Creep extends RoomObject {
     /**
      * An array describing the creep’s body. Each element contains the following properties:
      * type: string
@@ -587,10 +591,13 @@ declare class Creep extends RoomObject {
      */
     withdraw(target: Structure, resourceType: string, amount?: number): number;
 }
+interface CreepConstructor {
+}
+declare const Creep: CreepConstructor;
 /**
  * A flag. Flags can be used to mark particular spots in a room. Flags are visible to their owners only.
  */
-declare class Flag extends RoomObject {
+interface Flag extends RoomObject {
     /**
      * Flag color. One of the following constants: COLOR_WHITE, COLOR_GREY, COLOR_RED, COLOR_PURPLE, COLOR_BLUE, COLOR_CYAN, COLOR_GREEN, COLOR_YELLOW, COLOR_ORANGE, COLOR_BROWN
      */
@@ -635,6 +642,9 @@ declare class Flag extends RoomObject {
         pos: RoomPosition;
     }): number;
 }
+interface FlagConstructor {
+}
+declare const Flag: FlagConstructor;
 /**
  * The main global game object containing all the gameplay information.
  */
@@ -882,7 +892,7 @@ interface SurvivalGameInfo {
 /**
  * A global object representing world map. Use it to navigate between rooms. The object is accessible via Game.map property.
  */
-declare class GameMap {
+interface GameMap {
     /**
      * List all exits available from the room with the given name.
      * @param roomName The room name.
@@ -952,7 +962,7 @@ declare class GameMap {
  * A global object representing the in-game market. You can use this object to track resource transactions to/from your
  * terminals, and your buy/sell orders. The object is accessible via the singleton Game.market property.
  */
-declare class Market {
+interface Market {
     /**
      * Your current credits balance.
      */
@@ -1077,7 +1087,7 @@ interface Mineral extends RoomObject {
 /**
  * A nuke landing position. This object cannot be removed or modified. You can find incoming nukes in the room using the FIND_NUKES constant.
  */
-declare class Nuke extends RoomObject {
+interface Nuke extends RoomObject {
     /**
      * A unique object identificator. You can use Game.getObjectById method to retrieve an object instance by its id.
      */
@@ -1091,6 +1101,10 @@ declare class Nuke extends RoomObject {
      */
     timeToLand: number;
 }
+interface NukeConstructor {
+    new (id: string): Nuke;
+}
+declare const Nuke: NukeConstructor;
 /**
  * Contains powerful methods for pathfinding in the game world. Support exists for custom navigation costs and paths which span multiple rooms.
  * Additionally PathFinder can search for paths through rooms you can't see, although you won't be able to detect any dynamic obstacles like creeps or buildings.
@@ -1230,7 +1244,7 @@ interface RawMemory {
 /**
  * A dropped piece of resource. It will decay after a while if not picked up. Dropped resource pile decays for ceil(amount/1000) units per tick.
  */
-declare class Resource extends RoomObject {
+interface Resource extends RoomObject {
     /**
      * The amount of resource units containing.
      */
@@ -1244,11 +1258,15 @@ declare class Resource extends RoomObject {
      */
     resourceType: string;
 }
+interface ResourceConstructor {
+    new (id: string): Resource;
+}
+declare const Resource: ResourceConstructor;
 /**
  * Any object with a position in a room. Almost all game objects prototypes
  * are derived from RoomObject.
  */
-declare class RoomObject {
+interface RoomObject {
     prototype: RoomObject;
     /**
      * An object representing the position of this object in the room.
@@ -1261,17 +1279,13 @@ declare class RoomObject {
      */
     room: Room;
 }
+interface RoomObjectConstructor {
+}
+declare const RoomObject: RoomObjectConstructor;
 /**
  * An object representing the specified position in the room. Every object in the room contains RoomPosition as the pos property. The position object of a custom location can be obtained using the Room.getPositionAt() method or using the constructor.
  */
-declare class RoomPosition {
-    /**
-     * You can create new RoomPosition object using its constructor.
-     * @param x X position in the room.
-     * @param y Y position in the room.
-     * @param roomName The room name.
-     */
-    constructor(x: number, y: number, roomName: string);
+interface RoomPosition {
     /**
      * The name of the room.
      */
@@ -1431,10 +1445,20 @@ declare class RoomPosition {
      */
     lookFor<T>(type: string): T[];
 }
+interface RoomPositionConstructor {
+    /**
+     * You can create new RoomPosition object using its constructor.
+     * @param x X position in the room.
+     * @param y Y position in the room.
+     * @param roomName The room name.
+     */
+    new (x: number, y: number, roomName: string): RoomPosition;
+}
+declare const RoomPosition: RoomPositionConstructor;
 /**
  * An object representing the room in which your units and structures are in. It can be used to look around, find paths, etc. Every object in the room contains its linked Room instance in the room property.
  */
-declare class Room {
+interface Room {
     /**
      * The Controller structure of this room, if present, otherwise undefined.
      */
@@ -1590,23 +1614,17 @@ declare class Room {
      * @returns An object with all the objects of the given type in the specified area
      */
     lookForAtArea(type: string, top: number, left: number, bottom: number, right: number, asArray?: boolean): LookAtResultMatrix | LookAtResultWithPos[];
-    /**
-     * Serialize a path array into a short string representation, which is suitable to store in memory.
-     * @param path A path array retrieved from Room.findPath.
-     * @returns A serialized string form of the given path.
-     */
-    static serializePath(path: PathStep[]): string;
-    /**
-     * Deserialize a short string path representation into an array form.
-     * @param path A serialized path string.
-     * @returns A path array.
-     */
-    static deserializePath(path: string): PathStep[];
 }
+interface RoomConstructor {
+    new (id: string): Room;
+    serializePath(path: PathStep[]): string;
+    deserializePath(path: string): PathStep[];
+}
+declare const Room: RoomConstructor;
 /**
  * An energy source object. Can be harvested by creeps with a WORK body part.
  */
-declare class Source extends RoomObject {
+interface Source extends RoomObject {
     /**
      * The prototype is stored in the Source.prototype global object. You can use it to extend game objects behaviour globally:
      */
@@ -1628,10 +1646,14 @@ declare class Source extends RoomObject {
      */
     ticksToRegeneration: number;
 }
+interface SourceConstructor {
+    new (id: string): Source;
+}
+declare const Source: SourceConstructor;
 /**
  * Spawns are your colony centers. You can transfer energy into it and create new creeps using createCreep() method.
  */
-declare class Spawn extends OwnedStructure {
+interface StructureSpawn extends OwnedStructure {
     /**
      * The amount of energy containing in the spawn.
      */
@@ -1741,12 +1763,17 @@ declare class Spawn extends OwnedStructure {
      */
     transferEnergy(target: Creep, amount?: number): number;
 }
-declare class StructureSpawn extends Spawn {
+interface Spawn extends StructureSpawn {
 }
+interface StructureSpawnConstructor {
+    new (id: string): StructureSpawn;
+}
+declare const StructureSpawn: StructureSpawnConstructor;
+declare const Spawn: StructureSpawnConstructor;
 /**
  * Parent object for structure classes
  */
-declare class Structure extends RoomObject {
+interface Structure extends RoomObject {
     /**
      * The current amount of hit points of the structure.
      */
@@ -1777,11 +1804,15 @@ declare class Structure extends RoomObject {
      */
     notifyWhenAttacked(enabled: boolean): number;
 }
+interface StructureConstructor {
+    new (id: string): Structure;
+}
+declare const Structure: StructureConstructor;
 /**
  * The base prototype for a structure that has an owner. Such structures can be
  * found using `FIND_MY_STRUCTURES` and `FIND_HOSTILE_STRUCTURES` constants.
  */
-declare class OwnedStructure extends Structure {
+interface OwnedStructure extends Structure {
     /**
      * Whether this is your own structure. Walls and roads don't have this property as they are considered neutral structures.
      */
@@ -1791,12 +1822,16 @@ declare class OwnedStructure extends Structure {
      */
     owner: Owner;
 }
+interface OwnedStructureConstructor {
+    new (id: string): OwnedStructure;
+}
+declare const OwnedStructure: OwnedStructureConstructor;
 /**
  * Claim this structure to take control over the room. The controller structure
  * cannot be damaged or destroyed. It can be addressed by `Room.controller`
  * property.
  */
-declare class StructureController extends OwnedStructure {
+interface StructureController extends OwnedStructure {
     /**
      * Current controller level, from 0 to 8.
      */
@@ -1826,12 +1861,16 @@ declare class StructureController extends OwnedStructure {
      */
     unclaim(): number;
 }
+interface StructureControllerConstructor {
+    new (id: string): StructureController;
+}
+declare const StructureController: StructureControllerConstructor;
 /**
  * Contains energy which can be spent on spawning bigger creeps. Extensions can
  * be placed anywhere in the room, any spawns will be able to use them regardless
  * of distance.
  */
-declare class StructureExtension extends OwnedStructure {
+interface StructureExtension extends OwnedStructure {
     /**
      * The amount of energy containing in the extension.
      */
@@ -1847,10 +1886,14 @@ declare class StructureExtension extends OwnedStructure {
      */
     transferEnergy(target: Creep, amount?: number): number;
 }
+interface StructureExtensionConstructor {
+    new (id: string): StructureExtension;
+}
+declare const StructureExtension: StructureExtensionConstructor;
 /**
  * Remotely transfers energy to another Link in the same room.
  */
-declare class StructureLink extends OwnedStructure {
+interface StructureLink extends OwnedStructure {
     /**
      * The amount of game ticks the link has to wait until the next transfer is possible.
      */
@@ -1870,30 +1913,42 @@ declare class StructureLink extends OwnedStructure {
      */
     transferEnergy(target: Creep | StructureLink, amount?: number): number;
 }
+interface StructureLinkConstructor {
+    new (id: string): StructureLink;
+}
+declare const StructureLink: StructureLinkConstructor;
 /**
  * Non-player structure. Spawns NPC Source Keepers that guards energy sources
  * and minerals in some rooms. This structure cannot be destroyed.
  */
-declare class StructureKeeperLair extends OwnedStructure {
+interface StructureKeeperLair extends OwnedStructure {
     /**
      * Time to spawning of the next Source Keeper.
      */
     ticksToSpawn: number | undefined;
 }
+interface StructureKeeperLairConstructor {
+    new (id: string): StructureKeeperLair;
+}
+declare const StructureKeeperLair: StructureKeeperLairConstructor;
 /**
  * Provides visibility into a distant room from your script.
  */
-declare class StructureObserver extends OwnedStructure {
+interface StructureObserver extends OwnedStructure {
     /**
      * Provide visibility into a distant room from your script. The target room object will be available on the next tick. The maximum range is 5 rooms.
      * @param roomName
      */
     observeRoom(roomName: string): number;
 }
+interface StructureObserverConstructor {
+    new (id: string): StructureObserver;
+}
+declare const StructureObserver: StructureObserverConstructor;
 /**
  *
  */
-declare class StructurePowerBank extends OwnedStructure {
+interface StructurePowerBank extends OwnedStructure {
     /**
      * The amount of power containing.
      */
@@ -1903,11 +1958,15 @@ declare class StructurePowerBank extends OwnedStructure {
      */
     ticksToDecay: number;
 }
+interface StructurePowerBankConstructor {
+    new (id: string): StructurePowerBank;
+}
+declare const StructurePowerBank: StructurePowerBankConstructor;
 /**
  * Non-player structure. Contains power resource which can be obtained by
  * destroying the structure. Hits the attacker creep back on each attack.
  */
-declare class StructurePowerSpawn extends OwnedStructure {
+interface StructurePowerSpawn extends OwnedStructure {
     /**
      * The amount of energy containing in this structure.
      */
@@ -1940,11 +1999,15 @@ declare class StructurePowerSpawn extends OwnedStructure {
      */
     transferEnergy(target: Creep, amount?: number): number;
 }
+interface StructurePowerSpawnConstructor {
+    new (id: string): StructurePowerSpawn;
+}
+declare const StructurePowerSpawn: StructurePowerSpawnConstructor;
 /**
  * Blocks movement of hostile creeps, and defends your creeps and structures on
  * the same tile. Can be used as a controllable gate.
  */
-declare class StructureRampart extends OwnedStructure {
+interface StructureRampart extends OwnedStructure {
     /**
      * The amount of game ticks when this rampart will lose some hit points.
      */
@@ -1959,21 +2022,29 @@ declare class StructureRampart extends OwnedStructure {
      */
     setPublic(isPublic: boolean): any;
 }
+interface StructureRampartConstructor {
+    new (id: string): StructureRampart;
+}
+declare const StructureRampart: StructureRampartConstructor;
 /**
  * Decreases movement cost to 1. Using roads allows creating creeps with less
  * `MOVE` body parts.
  */
-declare class StructureRoad extends Structure {
+interface StructureRoad extends Structure {
     /**
      * The amount of game ticks when this road will lose some hit points.
      */
     ticksToDecay: number;
 }
+interface StructureRoadConstructor {
+    new (id: string): StructureRoad;
+}
+declare const StructureRoad: StructureRoadConstructor;
 /**
  * A structure that can store huge amount of resource units. Only one structure
  * per room is allowed that can be addressed by `Room.storage` property.
  */
-declare class StructureStorage extends OwnedStructure {
+interface StructureStorage extends OwnedStructure {
     /**
      * An object with the storage contents.
      */
@@ -1997,12 +2068,16 @@ declare class StructureStorage extends OwnedStructure {
      */
     transferEnergy(target: Creep, amount?: number): number;
 }
+interface StructureStorageConstructor {
+    new (id: string): StructureStorage;
+}
+declare const StructureStorage: StructureStorageConstructor;
 /**
  * Remotely attacks or heals creeps, or repairs structures. Can be targeted to
  * any object in the room. However, its effectiveness highly depends on the
  * distance. Each action consumes energy.
  */
-declare class StructureTower extends OwnedStructure {
+interface StructureTower extends OwnedStructure {
     /**
      * The amount of energy containing in this structure.
      */
@@ -2033,24 +2108,36 @@ declare class StructureTower extends OwnedStructure {
      */
     transferEnergy(target: Creep, amount?: number): number;
 }
+interface StructureTowerConstructor {
+    new (id: string): StructureTower;
+}
+declare const StructureTower: StructureTowerConstructor;
 /**
  * Blocks movement of all creeps.
  */
-declare class StructureWall extends Structure {
+interface StructureWall extends Structure {
     /**
      * The amount of game ticks when the wall will disappear (only for automatically placed border walls at the start of the game).
      */
     ticksToLive: number;
 }
+interface StructureWallConstructor {
+    new (id: string): StructureWall;
+}
+declare const StructureWall: StructureWallConstructor;
 /**
  * Allows to harvest mineral deposits.
  */
-declare class StructureExtractor extends OwnedStructure {
+interface StructureExtractor extends OwnedStructure {
 }
+interface StructureExtractorConstructor {
+    new (id: string): StructureExtractor;
+}
+declare const StructureExtractor: StructureExtractorConstructor;
 /**
  * Produces mineral compounds from base minerals and boosts creeps.
  */
-declare class StructureLab extends OwnedStructure {
+interface StructureLab extends OwnedStructure {
     /**
      * The amount of game ticks the lab has to wait until the next reaction is possible.
      */
@@ -2095,10 +2182,14 @@ declare class StructureLab extends OwnedStructure {
      */
     transfer(target: Creep, resourceType: string, amount?: number): number;
 }
+interface StructureLabConstructor {
+    new (id: string): StructureLab;
+}
+declare const StructureLab: StructureLabConstructor;
 /**
  * Sends any resources to a Terminal in another room.
  */
-declare class StructureTerminal extends OwnedStructure {
+interface StructureTerminal extends OwnedStructure {
     /**
      * An object with the storage contents. Each object key is one of the RESOURCE_* constants, values are resources amounts.
      */
@@ -2123,10 +2214,14 @@ declare class StructureTerminal extends OwnedStructure {
      */
     transfer(target: Creep, resourceType: String, amount?: number): number;
 }
+interface StructureTerminalConstructor {
+    new (id: string): StructureTerminal;
+}
+declare const StructureTerminal: StructureTerminalConstructor;
 /**
  * Contains up to 2,000 resource units. Can be constructed in neutral rooms. Decays for 5,000 hits per 100 ticks.
  */
-declare class StructureContainer extends Structure {
+interface StructureContainer extends Structure {
     /**
      * An object with the structure contents. Each object key is one of the RESOURCE_* constants, values are resources
      * amounts. Use _.sum(structure.store) to get the total amount of contents
@@ -2144,6 +2239,10 @@ declare class StructureContainer extends Structure {
      */
     transfer(target: Creep, resourceType: string, amount?: number): number;
 }
+interface StructureContainerConstructor {
+    new (id: string): StructureContainer;
+}
+declare const StructureContainer: StructureContainerConstructor;
 /**
  * Launches a nuke to another room dealing huge damage to the landing area.
  * Each launch has a cooldown and requires energy and ghodium resources. Launching
@@ -2151,7 +2250,7 @@ declare class StructureContainer extends Structure {
  * until it is landed. Incoming nuke cannot be moved or cancelled. Nukes cannot
  * be launched from or to novice rooms.
  */
-declare class StructureNuker extends OwnedStructure {
+interface StructureNuker extends OwnedStructure {
     /**
      * The amount of energy contained in this structure.
      */
@@ -2178,12 +2277,16 @@ declare class StructureNuker extends OwnedStructure {
      */
     launchNuke(pos: RoomPosition): number;
 }
+interface StructureNukerConstructor {
+    new (id: string): StructureNuker;
+}
+declare const StructureNuker: StructureNukerConstructor;
 /**
  * A non-player structure.
  * Instantly teleports your creeps to a distant room acting as a room exit tile.
  * Portals appear randomly in the central room of each sector.
  */
-declare class StructurePortal extends Structure {
+interface StructurePortal extends Structure {
     /**
      * The position object in the destination room.
      */
@@ -2193,3 +2296,7 @@ declare class StructurePortal extends Structure {
      */
     ticksToDecay: number;
 }
+interface StructurePortalConstructor {
+    new (id: string): StructurePortal;
+}
+declare const StructurePortal: StructurePortalConstructor;

--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -330,6 +330,7 @@ declare var ORDER_BUY: string;
  * A site of a structure which is currently under construction.
  */
 interface ConstructionSite extends RoomObject {
+    readonly prototype: ConstructionSite;
     /**
      * A unique object identificator. You can use Game.getObjectById method to retrieve an object instance by its id.
      */
@@ -360,8 +361,7 @@ interface ConstructionSite extends RoomObject {
      */
     remove(): number;
 }
-interface ConstructionSiteConstructor {
-    new (id: string): ConstructionSite;
+interface ConstructionSiteConstructor extends _Constructor<ConstructionSite>, _ConstructorById<ConstructionSite> {
 }
 declare const ConstructionSite: ConstructionSiteConstructor;
 declare var Memory: Memory;
@@ -380,11 +380,13 @@ declare type Terminal = StructureTerminal;
 declare type Container = StructureContainer;
 declare type Tower = StructureTower;
 interface Storage extends StructureStorage {
+    readonly prototype: StructureStorage;
 }
 /**
  * Creeps are your units. Creeps can move, harvest energy, construct structures, attack another creeps, and perform other actions. Each creep consists of up to 50 body parts with the following possible types:
  */
 interface Creep extends RoomObject {
+    readonly prototype: Creep;
     /**
      * An array describing the creep’s body. Each element contains the following properties:
      * type: string
@@ -591,13 +593,14 @@ interface Creep extends RoomObject {
      */
     withdraw(target: Structure, resourceType: string, amount?: number): number;
 }
-interface CreepConstructor {
+interface CreepConstructor extends _Constructor<Creep>, _ConstructorById<Creep> {
 }
 declare const Creep: CreepConstructor;
 /**
  * A flag. Flags can be used to mark particular spots in a room. Flags are visible to their owners only.
  */
 interface Flag extends RoomObject {
+    readonly prototype: Flag;
     /**
      * Flag color. One of the following constants: COLOR_WHITE, COLOR_GREY, COLOR_RED, COLOR_PURPLE, COLOR_BLUE, COLOR_CYAN, COLOR_GREEN, COLOR_YELLOW, COLOR_ORANGE, COLOR_BROWN
      */
@@ -618,7 +621,7 @@ interface Flag extends RoomObject {
      * Remove the flag.
      * @returns Result Code: OK
      */
-    remove(): void;
+    remove(): number;
     /**
      * Set new color of the flag.
      * @param color One of the following constants: COLOR_WHITE, COLOR_GREY, COLOR_RED, COLOR_PURPLE, COLOR_BLUE, COLOR_CYAN, COLOR_GREEN, COLOR_YELLOW, COLOR_ORANGE, COLOR_BROWN
@@ -642,7 +645,9 @@ interface Flag extends RoomObject {
         pos: RoomPosition;
     }): number;
 }
-interface FlagConstructor {
+interface FlagConstructor extends _Constructor<Flag> {
+    new (name: string, color: number, secondaryColor: number, roomName: string, x: number, y: number): Flag;
+    (name: string, color: number, secondaryColor: number, roomName: string, x: number, y: number): Flag;
 }
 declare const Flag: FlagConstructor;
 /**
@@ -889,6 +894,13 @@ interface SurvivalGameInfo {
      */
     wave: number;
 }
+interface _Constructor<T> {
+    readonly prototype: T;
+}
+interface _ConstructorById<T> extends _Constructor<T> {
+    new (id: string): T;
+    (id: string): T;
+}
 /**
  * A global object representing world map. Use it to navigate between rooms. The object is accessible via Game.map property.
  */
@@ -1066,7 +1078,7 @@ interface Mineral extends RoomObject {
     /**
      * The prototype is stored in the Mineral.prototype global object. You can use it to extend game objects behaviour globally.
      */
-    prototype: Mineral;
+    readonly prototype: Mineral;
     /**
      * The remaining amount of resources.
      */
@@ -1084,10 +1096,14 @@ interface Mineral extends RoomObject {
      */
     ticksToRegeneration: number;
 }
+interface MineralConstructor extends _Constructor<Mineral>, _ConstructorById<Mineral> {
+}
+declare const Mineral: MineralConstructor;
 /**
  * A nuke landing position. This object cannot be removed or modified. You can find incoming nukes in the room using the FIND_NUKES constant.
  */
 interface Nuke extends RoomObject {
+    readonly prototype: Nuke;
     /**
      * A unique object identificator. You can use Game.getObjectById method to retrieve an object instance by its id.
      */
@@ -1245,6 +1261,7 @@ interface RawMemory {
  * A dropped piece of resource. It will decay after a while if not picked up. Dropped resource pile decays for ceil(amount/1000) units per tick.
  */
 interface Resource extends RoomObject {
+    readonly prototype: Resource;
     /**
      * The amount of resource units containing.
      */
@@ -1267,7 +1284,7 @@ declare const Resource: ResourceConstructor;
  * are derived from RoomObject.
  */
 interface RoomObject {
-    prototype: RoomObject;
+    readonly prototype: RoomObject;
     /**
      * An object representing the position of this object in the room.
      */
@@ -1279,13 +1296,16 @@ interface RoomObject {
      */
     room: Room;
 }
-interface RoomObjectConstructor {
+interface RoomObjectConstructor extends _Constructor<RoomObject> {
+    new (x: number, y: number, roomName: string): RoomObject;
+    (x: number, y: number, roomName: string): RoomObject;
 }
 declare const RoomObject: RoomObjectConstructor;
 /**
  * An object representing the specified position in the room. Every object in the room contains RoomPosition as the pos property. The position object of a custom location can be obtained using the Room.getPositionAt() method or using the constructor.
  */
 interface RoomPosition {
+    readonly prototype: RoomPosition;
     /**
      * The name of the room.
      */
@@ -1445,7 +1465,7 @@ interface RoomPosition {
      */
     lookFor<T>(type: string): T[];
 }
-interface RoomPositionConstructor {
+interface RoomPositionConstructor extends _Constructor<RoomPosition> {
     /**
      * You can create new RoomPosition object using its constructor.
      * @param x X position in the room.
@@ -1453,12 +1473,14 @@ interface RoomPositionConstructor {
      * @param roomName The room name.
      */
     new (x: number, y: number, roomName: string): RoomPosition;
+    (x: number, y: number, roomName: string): RoomPosition;
 }
 declare const RoomPosition: RoomPositionConstructor;
 /**
  * An object representing the room in which your units and structures are in. It can be used to look around, find paths, etc. Every object in the room contains its linked Room instance in the room property.
  */
 interface Room {
+    readonly prototype: Room;
     /**
      * The Controller structure of this room, if present, otherwise undefined.
      */
@@ -1628,7 +1650,7 @@ interface Source extends RoomObject {
     /**
      * The prototype is stored in the Source.prototype global object. You can use it to extend game objects behaviour globally:
      */
-    prototype: Source;
+    readonly prototype: Source;
     /**
      * The remaining amount of energy.
      */
@@ -1646,14 +1668,14 @@ interface Source extends RoomObject {
      */
     ticksToRegeneration: number;
 }
-interface SourceConstructor {
-    new (id: string): Source;
+interface SourceConstructor extends _Constructor<Source>, _ConstructorById<Source> {
 }
 declare const Source: SourceConstructor;
 /**
  * Spawns are your colony centers. You can transfer energy into it and create new creeps using createCreep() method.
  */
 interface StructureSpawn extends OwnedStructure {
+    readonly prototype: StructureSpawn;
     /**
      * The amount of energy containing in the spawn.
      */
@@ -1763,17 +1785,18 @@ interface StructureSpawn extends OwnedStructure {
      */
     transferEnergy(target: Creep, amount?: number): number;
 }
-interface Spawn extends StructureSpawn {
-}
-interface StructureSpawnConstructor {
-    new (id: string): StructureSpawn;
+interface StructureSpawnConstructor extends _Constructor<StructureSpawn>, _ConstructorById<StructureSpawn> {
 }
 declare const StructureSpawn: StructureSpawnConstructor;
+interface Spawn extends StructureSpawn {
+    readonly prototype: StructureSpawn;
+}
 declare const Spawn: StructureSpawnConstructor;
 /**
  * Parent object for structure classes
  */
 interface Structure extends RoomObject {
+    readonly prototype: Structure;
     /**
      * The current amount of hit points of the structure.
      */
@@ -1804,8 +1827,7 @@ interface Structure extends RoomObject {
      */
     notifyWhenAttacked(enabled: boolean): number;
 }
-interface StructureConstructor {
-    new (id: string): Structure;
+interface StructureConstructor extends _Constructor<Structure>, _ConstructorById<Structure> {
 }
 declare const Structure: StructureConstructor;
 /**
@@ -1813,6 +1835,7 @@ declare const Structure: StructureConstructor;
  * found using `FIND_MY_STRUCTURES` and `FIND_HOSTILE_STRUCTURES` constants.
  */
 interface OwnedStructure extends Structure {
+    readonly prototype: OwnedStructure;
     /**
      * Whether this is your own structure. Walls and roads don't have this property as they are considered neutral structures.
      */
@@ -1822,8 +1845,7 @@ interface OwnedStructure extends Structure {
      */
     owner: Owner;
 }
-interface OwnedStructureConstructor {
-    new (id: string): OwnedStructure;
+interface OwnedStructureConstructor extends _Constructor<OwnedStructure>, _ConstructorById<OwnedStructure> {
 }
 declare const OwnedStructure: OwnedStructureConstructor;
 /**
@@ -1832,6 +1854,7 @@ declare const OwnedStructure: OwnedStructureConstructor;
  * property.
  */
 interface StructureController extends OwnedStructure {
+    readonly prototype: StructureController;
     /**
      * Current controller level, from 0 to 8.
      */
@@ -1861,8 +1884,7 @@ interface StructureController extends OwnedStructure {
      */
     unclaim(): number;
 }
-interface StructureControllerConstructor {
-    new (id: string): StructureController;
+interface StructureControllerConstructor extends _Constructor<StructureController>, _ConstructorById<StructureController> {
 }
 declare const StructureController: StructureControllerConstructor;
 /**
@@ -1871,6 +1893,7 @@ declare const StructureController: StructureControllerConstructor;
  * of distance.
  */
 interface StructureExtension extends OwnedStructure {
+    readonly prototype: StructureExtension;
     /**
      * The amount of energy containing in the extension.
      */
@@ -1886,14 +1909,14 @@ interface StructureExtension extends OwnedStructure {
      */
     transferEnergy(target: Creep, amount?: number): number;
 }
-interface StructureExtensionConstructor {
-    new (id: string): StructureExtension;
+interface StructureExtensionConstructor extends _Constructor<StructureExtension>, _ConstructorById<StructureExtension> {
 }
 declare const StructureExtension: StructureExtensionConstructor;
 /**
  * Remotely transfers energy to another Link in the same room.
  */
 interface StructureLink extends OwnedStructure {
+    readonly prototype: StructureLink;
     /**
      * The amount of game ticks the link has to wait until the next transfer is possible.
      */
@@ -1913,8 +1936,7 @@ interface StructureLink extends OwnedStructure {
      */
     transferEnergy(target: Creep | StructureLink, amount?: number): number;
 }
-interface StructureLinkConstructor {
-    new (id: string): StructureLink;
+interface StructureLinkConstructor extends _Constructor<StructureLink>, _ConstructorById<StructureLink> {
 }
 declare const StructureLink: StructureLinkConstructor;
 /**
@@ -1922,33 +1944,34 @@ declare const StructureLink: StructureLinkConstructor;
  * and minerals in some rooms. This structure cannot be destroyed.
  */
 interface StructureKeeperLair extends OwnedStructure {
+    readonly prototype: StructureKeeperLair;
     /**
      * Time to spawning of the next Source Keeper.
      */
     ticksToSpawn: number | undefined;
 }
-interface StructureKeeperLairConstructor {
-    new (id: string): StructureKeeperLair;
+interface StructureKeeperLairConstructor extends _Constructor<StructureKeeperLair>, _ConstructorById<StructureKeeperLair> {
 }
 declare const StructureKeeperLair: StructureKeeperLairConstructor;
 /**
  * Provides visibility into a distant room from your script.
  */
 interface StructureObserver extends OwnedStructure {
+    readonly prototype: StructureObserver;
     /**
      * Provide visibility into a distant room from your script. The target room object will be available on the next tick. The maximum range is 5 rooms.
      * @param roomName
      */
     observeRoom(roomName: string): number;
 }
-interface StructureObserverConstructor {
-    new (id: string): StructureObserver;
+interface StructureObserverConstructor extends _Constructor<StructureObserver>, _ConstructorById<StructureObserver> {
 }
 declare const StructureObserver: StructureObserverConstructor;
 /**
  *
  */
 interface StructurePowerBank extends OwnedStructure {
+    readonly prototype: StructurePowerBank;
     /**
      * The amount of power containing.
      */
@@ -1958,8 +1981,7 @@ interface StructurePowerBank extends OwnedStructure {
      */
     ticksToDecay: number;
 }
-interface StructurePowerBankConstructor {
-    new (id: string): StructurePowerBank;
+interface StructurePowerBankConstructor extends _Constructor<StructurePowerBank>, _ConstructorById<StructurePowerBank> {
 }
 declare const StructurePowerBank: StructurePowerBankConstructor;
 /**
@@ -1967,6 +1989,7 @@ declare const StructurePowerBank: StructurePowerBankConstructor;
  * destroying the structure. Hits the attacker creep back on each attack.
  */
 interface StructurePowerSpawn extends OwnedStructure {
+    readonly prototype: StructurePowerSpawn;
     /**
      * The amount of energy containing in this structure.
      */
@@ -1999,8 +2022,7 @@ interface StructurePowerSpawn extends OwnedStructure {
      */
     transferEnergy(target: Creep, amount?: number): number;
 }
-interface StructurePowerSpawnConstructor {
-    new (id: string): StructurePowerSpawn;
+interface StructurePowerSpawnConstructor extends _Constructor<StructurePowerSpawn>, _ConstructorById<StructurePowerSpawn> {
 }
 declare const StructurePowerSpawn: StructurePowerSpawnConstructor;
 /**
@@ -2008,6 +2030,7 @@ declare const StructurePowerSpawn: StructurePowerSpawnConstructor;
  * the same tile. Can be used as a controllable gate.
  */
 interface StructureRampart extends OwnedStructure {
+    readonly prototype: StructureRampart;
     /**
      * The amount of game ticks when this rampart will lose some hit points.
      */
@@ -2022,8 +2045,7 @@ interface StructureRampart extends OwnedStructure {
      */
     setPublic(isPublic: boolean): any;
 }
-interface StructureRampartConstructor {
-    new (id: string): StructureRampart;
+interface StructureRampartConstructor extends _Constructor<StructureRampart>, _ConstructorById<StructureRampart> {
 }
 declare const StructureRampart: StructureRampartConstructor;
 /**
@@ -2031,13 +2053,13 @@ declare const StructureRampart: StructureRampartConstructor;
  * `MOVE` body parts.
  */
 interface StructureRoad extends Structure {
+    readonly prototype: StructureRoad;
     /**
      * The amount of game ticks when this road will lose some hit points.
      */
     ticksToDecay: number;
 }
-interface StructureRoadConstructor {
-    new (id: string): StructureRoad;
+interface StructureRoadConstructor extends _Constructor<StructureRoad>, _ConstructorById<StructureRoad> {
 }
 declare const StructureRoad: StructureRoadConstructor;
 /**
@@ -2045,6 +2067,7 @@ declare const StructureRoad: StructureRoadConstructor;
  * per room is allowed that can be addressed by `Room.storage` property.
  */
 interface StructureStorage extends OwnedStructure {
+    readonly prototype: StructureStorage;
     /**
      * An object with the storage contents.
      */
@@ -2068,8 +2091,7 @@ interface StructureStorage extends OwnedStructure {
      */
     transferEnergy(target: Creep, amount?: number): number;
 }
-interface StructureStorageConstructor {
-    new (id: string): StructureStorage;
+interface StructureStorageConstructor extends _Constructor<StructureStorage>, _ConstructorById<StructureStorage> {
 }
 declare const StructureStorage: StructureStorageConstructor;
 /**
@@ -2078,6 +2100,7 @@ declare const StructureStorage: StructureStorageConstructor;
  * distance. Each action consumes energy.
  */
 interface StructureTower extends OwnedStructure {
+    readonly prototype: StructureTower;
     /**
      * The amount of energy containing in this structure.
      */
@@ -2108,36 +2131,36 @@ interface StructureTower extends OwnedStructure {
      */
     transferEnergy(target: Creep, amount?: number): number;
 }
-interface StructureTowerConstructor {
-    new (id: string): StructureTower;
+interface StructureTowerConstructor extends _Constructor<StructureTower>, _ConstructorById<StructureTower> {
 }
 declare const StructureTower: StructureTowerConstructor;
 /**
  * Blocks movement of all creeps.
  */
 interface StructureWall extends Structure {
+    readonly prototype: StructureWall;
     /**
      * The amount of game ticks when the wall will disappear (only for automatically placed border walls at the start of the game).
      */
     ticksToLive: number;
 }
-interface StructureWallConstructor {
-    new (id: string): StructureWall;
+interface StructureWallConstructor extends _Constructor<StructureWall>, _ConstructorById<StructureWall> {
 }
 declare const StructureWall: StructureWallConstructor;
 /**
  * Allows to harvest mineral deposits.
  */
 interface StructureExtractor extends OwnedStructure {
+    readonly prototype: StructureExtractor;
 }
-interface StructureExtractorConstructor {
-    new (id: string): StructureExtractor;
+interface StructureExtractorConstructor extends _Constructor<StructureExtractor>, _ConstructorById<StructureExtractor> {
 }
 declare const StructureExtractor: StructureExtractorConstructor;
 /**
  * Produces mineral compounds from base minerals and boosts creeps.
  */
 interface StructureLab extends OwnedStructure {
+    readonly prototype: StructureLab;
     /**
      * The amount of game ticks the lab has to wait until the next reaction is possible.
      */
@@ -2182,14 +2205,14 @@ interface StructureLab extends OwnedStructure {
      */
     transfer(target: Creep, resourceType: string, amount?: number): number;
 }
-interface StructureLabConstructor {
-    new (id: string): StructureLab;
+interface StructureLabConstructor extends _Constructor<StructureLab>, _ConstructorById<StructureLab> {
 }
 declare const StructureLab: StructureLabConstructor;
 /**
  * Sends any resources to a Terminal in another room.
  */
 interface StructureTerminal extends OwnedStructure {
+    readonly prototype: StructureTerminal;
     /**
      * An object with the storage contents. Each object key is one of the RESOURCE_* constants, values are resources amounts.
      */
@@ -2214,14 +2237,14 @@ interface StructureTerminal extends OwnedStructure {
      */
     transfer(target: Creep, resourceType: String, amount?: number): number;
 }
-interface StructureTerminalConstructor {
-    new (id: string): StructureTerminal;
+interface StructureTerminalConstructor extends _Constructor<StructureTerminal>, _ConstructorById<StructureTerminal> {
 }
 declare const StructureTerminal: StructureTerminalConstructor;
 /**
  * Contains up to 2,000 resource units. Can be constructed in neutral rooms. Decays for 5,000 hits per 100 ticks.
  */
 interface StructureContainer extends Structure {
+    readonly prototype: StructureContainer;
     /**
      * An object with the structure contents. Each object key is one of the RESOURCE_* constants, values are resources
      * amounts. Use _.sum(structure.store) to get the total amount of contents
@@ -2239,8 +2262,7 @@ interface StructureContainer extends Structure {
      */
     transfer(target: Creep, resourceType: string, amount?: number): number;
 }
-interface StructureContainerConstructor {
-    new (id: string): StructureContainer;
+interface StructureContainerConstructor extends _Constructor<StructureContainer>, _ConstructorById<StructureContainer> {
 }
 declare const StructureContainer: StructureContainerConstructor;
 /**
@@ -2251,6 +2273,7 @@ declare const StructureContainer: StructureContainerConstructor;
  * be launched from or to novice rooms.
  */
 interface StructureNuker extends OwnedStructure {
+    readonly prototype: StructureNuker;
     /**
      * The amount of energy contained in this structure.
      */
@@ -2277,8 +2300,7 @@ interface StructureNuker extends OwnedStructure {
      */
     launchNuke(pos: RoomPosition): number;
 }
-interface StructureNukerConstructor {
-    new (id: string): StructureNuker;
+interface StructureNukerConstructor extends _Constructor<StructureNuker>, _ConstructorById<StructureNuker> {
 }
 declare const StructureNuker: StructureNukerConstructor;
 /**
@@ -2287,6 +2309,7 @@ declare const StructureNuker: StructureNukerConstructor;
  * Portals appear randomly in the central room of each sector.
  */
 interface StructurePortal extends Structure {
+    readonly prototype: StructurePortal;
     /**
      * The position object in the destination room.
      */
@@ -2296,7 +2319,6 @@ interface StructurePortal extends Structure {
      */
     ticksToDecay: number;
 }
-interface StructurePortalConstructor {
-    new (id: string): StructurePortal;
+interface StructurePortalConstructor extends _Constructor<StructurePortal>, _ConstructorById<StructurePortal> {
 }
 declare const StructurePortal: StructurePortalConstructor;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,74 +3,418 @@
  * This might need some updates when Screeps publishes new features or changes it's existing API
  */
 
-declare var FIND_EXIT_TOP: number;
-declare var FIND_EXIT_RIGHT: number;
-declare var FIND_EXIT_BOTTOM: number;
-declare var FIND_EXIT_LEFT: number;
-declare var FIND_EXIT: number;
-declare var FIND_CREEPS: number;
-declare var FIND_MY_CREEPS: number;
-declare var FIND_HOSTILE_CREEPS: number;
-declare var FIND_SOURCES_ACTIVE: number;
-declare var FIND_SOURCES: number;
-declare var FIND_DROPPED_RESOURCES: number;
-declare var FIND_DROPPED_ENERGY: number;
-declare var FIND_STRUCTURES: number;
-declare var FIND_MY_STRUCTURES: number;
-declare var FIND_HOSTILE_STRUCTURES: number;
-declare var FIND_FLAGS: number;
-declare var FIND_CONSTRUCTION_SITES: number;
-declare var FIND_MY_CONSTRUCTION_SITES: number;
-declare var FIND_HOSTILE_CONSTRUCTION_SITES: number;
-declare var FIND_MY_SPAWNS: number;
-declare var FIND_HOSTILE_SPAWNS: number;
-declare var FIND_MINERALS: number;
+type FindConst = FindConstExit | FindConstExitAny | FindConstTypeCreep | FindConstTypeSource | FindConstTypeResource | FindConstTypeStructure | FindConstTypeFlag | FindConstTypeConstructionSite | FindConstTypeSpawn | FindConstTypeMineral | FindConstTypeNuke;
 
-declare var TOP: number;
-declare var TOP_RIGHT: number;
-declare var RIGHT: number;
-declare var BOTTOM_RIGHT: number;
-declare var BOTTOM: number;
-declare var BOTTOM_LEFT: number;
-declare var LEFT: number;
-declare var TOP_LEFT: number;
+type FindConstExit = FindConstExitTop | FindConstExitRight | FindConstExitBottom | FindConstExitLeft;
+type FindConstExitTop = DirConstTop;
+type FindConstExitRight = DirConstRight;
+type FindConstExitBottom = DirConstBottom;
+type FindConstExitLeft = DirConstLeft;
+type FindConstExitAny = 10;
 
-declare var OK: number;
-declare var ERR_NOT_OWNER: number;
-declare var ERR_NO_PATH: number;
-declare var ERR_NAME_EXISTS: number;
-declare var ERR_BUSY: number;
-declare var ERR_NOT_FOUND: number;
-declare var ERR_NOT_ENOUGH_RESOURCES: number;
-declare var ERR_NOT_ENOUGH_ENERGY: number;
-declare var ERR_INVALID_TARGET: number;
-declare var ERR_FULL: number;
-declare var ERR_NOT_IN_RANGE: number;
-declare var ERR_INVALID_ARGS: number;
-declare var ERR_TIRED: number;
-declare var ERR_NO_BODYPART: number;
-declare var ERR_NOT_ENOUGH_EXTENSIONS: number;
-declare var ERR_RCL_NOT_ENOUGH: number;
-declare var ERR_GCL_NOT_ENOUGH: number;
+type FindConstTypeCreep = FindConstCreep | FindConstMyCreep | FindConstHostileCreep;
+type FindConstCreep = 101;
+type FindConstMyCreep = 102;
+type FindConstHostileCreep = 103;
 
-declare var COLOR_RED: number;
-declare var COLOR_PURPLE: number;
-declare var COLOR_BLUE: number;
-declare var COLOR_CYAN: number;
-declare var COLOR_GREEN: number;
-declare var COLOR_YELLOW: number;
-declare var COLOR_ORANGE: number;
-declare var COLOR_BROWN: number;
-declare var COLOR_GREY: number;
-declare var COLOR_WHITE: number;
-declare var COLORS_ALL: number[];
+type FindConstTypeSource = FindConstSourceActive | FindConstSource;
+type FindConstSourceActive = 104;
+type FindConstSource = 105;
+
+type FindConstTypeResource = FindConstResource;
+type FindConstResource = 106;
+
+type FindConstTypeStructure = FindConstStructure | FindConstMyStructure | FindConstHostileStructure;
+type FindConstStructure = 107;
+type FindConstMyStructure = 108;
+type FindConstHostileStructure = 109;
+
+type FindConstTypeFlag = FindConstFlag;
+type FindConstFlag = 110;
+
+type FindConstTypeConstructionSite = FindConstConstructionSite | FindConstMyConstructionSite | FindConstHostileConstructionSite;
+type FindConstConstructionSite = 111;
+type FindConstMyConstructionSite = 114;
+type FindConstHostileConstructionSite = 115;
+
+type FindConstTypeSpawn = FindConstMySpawn | FindConstHostileSpawn;
+type FindConstMySpawn = 112;
+type FindConstHostileSpawn = 113;
+
+type FindConstTypeMineral = FindConstMineral;
+type FindConstMineral = 116;
+
+type FindConstTypeNuke = FindConstNuke;
+type FindConstNuke = 117;
+
+declare var FIND_EXIT_TOP:                   FindConstExitTop;
+declare var FIND_EXIT_RIGHT:                 FindConstExitRight;
+declare var FIND_EXIT_BOTTOM:                FindConstExitBottom;
+declare var FIND_EXIT_LEFT:                  FindConstExitLeft;
+declare var FIND_EXIT:                       FindConstExitAny;
+declare var FIND_CREEPS:                     FindConstCreep;
+declare var FIND_MY_CREEPS:                  FindConstMyCreep;
+declare var FIND_HOSTILE_CREEPS:             FindConstHostileCreep;
+declare var FIND_SOURCES_ACTIVE:             FindConstSourceActive;
+declare var FIND_SOURCES:                    FindConstSource;
+declare var FIND_DROPPED_ENERGY:             FindConstResource;
+declare var FIND_DROPPED_RESOURCES:          FindConstResource;
+declare var FIND_STRUCTURES:                 FindConstStructure;
+declare var FIND_MY_STRUCTURES:              FindConstMyStructure;
+declare var FIND_HOSTILE_STRUCTURES:         FindConstHostileStructure;
+declare var FIND_FLAGS:                      FindConstFlag;
+declare var FIND_CONSTRUCTION_SITES:         FindConstConstructionSite;
+declare var FIND_MY_SPAWNS:                  FindConstMySpawn;
+declare var FIND_HOSTILE_SPAWNS:             FindConstHostileSpawn;
+declare var FIND_MY_CONSTRUCTION_SITES:      FindConstMyConstructionSite;
+declare var FIND_HOSTILE_CONSTRUCTION_SITES: FindConstHostileConstructionSite;
+declare var FIND_MINERALS:                   FindConstMineral;
+declare var FIND_NUKES:                      FindConstNuke;
+
+type DirConst = DirConstTop | DirConstTopRight | DirConstRight | DirConstBottomRight | DirConstBottom | DirConstBottomLeft | DirConstLeft | DirConstTopLeft;
+type DirConstTop = 1;
+type DirConstTopRight = 2;
+type DirConstRight = 3;
+type DirConstBottomRight = 4;
+type DirConstBottom = 5;
+type DirConstBottomLeft = 6;
+type DirConstLeft = 7;
+type DirConstTopLeft = 8;
+
+declare var TOP:          DirConstTop;
+declare var TOP_RIGHT:    DirConstTopRight;
+declare var RIGHT:        DirConstRight;
+declare var BOTTOM_RIGHT: DirConstBottomRight;
+declare var BOTTOM:       DirConstBottom;
+declare var BOTTOM_LEFT:  DirConstBottomLeft;
+declare var LEFT:         DirConstLeft;
+declare var TOP_LEFT:     DirConstTopLeft;
+
+type ReturnConst =
+    ReturnConstOk
+    | ReturnConstErrNotOwner
+    | ReturnConstErrNoPath
+    | ReturnConstErrNameExists
+    | ReturnConstErrBusy
+    | ReturnConstErrNotFound
+    | ReturnConstErrNotEnough
+    | ReturnConstErrInvalidTarget
+    | ReturnConstErrFull
+    | ReturnConstErrNotInRange
+    | ReturnConstErrInvalidArgs
+    | ReturnConstErrTired
+    | ReturnConstErrNoBodypart
+    | ReturnConstErrRCL
+    | ReturnConstErrGCL
+;
+type ReturnConstOk = 0;
+type ReturnConstErrNotOwner = -1;
+type ReturnConstErrNoPath = -2;
+type ReturnConstErrNameExists = -3;
+type ReturnConstErrBusy = -4;
+type ReturnConstErrNotFound = -5;
+type ReturnConstErrNotEnough = -6;
+type ReturnConstErrInvalidTarget = -7;
+type ReturnConstErrFull = -8;
+type ReturnConstErrNotInRange = -9;
+type ReturnConstErrInvalidArgs = -10;
+type ReturnConstErrTired = -11;
+type ReturnConstErrNoBodypart = -12;
+type ReturnConstErrRCL = -14;
+type ReturnConstErrGCL = -15;
+
+declare var OK:                        ReturnConstOk;
+declare var ERR_NOT_OWNER:             ReturnConstErrNotOwner;
+declare var ERR_NO_PATH:               ReturnConstErrNoPath;
+declare var ERR_NAME_EXISTS:           ReturnConstErrNameExists;
+declare var ERR_BUSY:                  ReturnConstErrBusy;
+declare var ERR_NOT_FOUND:             ReturnConstErrNotFound;
+declare var ERR_NOT_ENOUGH_RESOURCES:  ReturnConstErrNotEnough;
+declare var ERR_NOT_ENOUGH_ENERGY:     ReturnConstErrNotEnough;
+declare var ERR_INVALID_TARGET:        ReturnConstErrInvalidTarget;
+declare var ERR_FULL:                  ReturnConstErrFull;
+declare var ERR_NOT_IN_RANGE:          ReturnConstErrNotInRange;
+declare var ERR_INVALID_ARGS:          ReturnConstErrInvalidArgs;
+declare var ERR_TIRED:                 ReturnConstErrTired;
+declare var ERR_NO_BODYPART:           ReturnConstErrNoBodypart;
+declare var ERR_NOT_ENOUGH_EXTENSIONS: ReturnConstErrNotEnough;
+declare var ERR_RCL_NOT_ENOUGH:        ReturnConstErrRCL;
+declare var ERR_GCL_NOT_ENOUGH:        ReturnConstErrGCL;
+
+type ColorConst = ColorConstRed | ColorConstPurple | ColorConstBlue | ColorConstCyan | ColorConstGreen | ColorConstYellow | ColorConstOrange | ColorConstBrown | ColorConstGrey | ColorConstWhite;
+type ColorConstRed = 1;
+type ColorConstPurple = 2;
+type ColorConstBlue = 3;
+type ColorConstCyan = 4;
+type ColorConstGreen = 5;
+type ColorConstYellow = 6;
+type ColorConstOrange = 7;
+type ColorConstBrown = 8;
+type ColorConstGrey = 9;
+type ColorConstWhite = 10;
+
+declare var COLOR_RED:    ColorConstRed;
+declare var COLOR_PURPLE: ColorConstPurple;
+declare var COLOR_BLUE:   ColorConstBlue;
+declare var COLOR_CYAN:   ColorConstCyan;
+declare var COLOR_GREEN:  ColorConstGreen;
+declare var COLOR_YELLOW: ColorConstYellow;
+declare var COLOR_ORANGE: ColorConstOrange;
+declare var COLOR_BROWN:  ColorConstBrown;
+declare var COLOR_GREY:   ColorConstGrey;
+declare var COLOR_WHITE:  ColorConstWhite;
+declare var COLORS_ALL:   ColorConst[];
+
+type LookConst = LookConstCreep | LookConstEnergy | LookConstResource | LookConstSource | LookConstMineral | LookConstStructure | LookConstFlag | LookConstConstructionSite | LookConstNuke | LookConstTerrain;
+type LookConstCreep = "creep";
+type LookConstEnergy = "energy"
+type LookConstResource = "resource";
+type LookConstSource = "source";
+type LookConstMineral = "mineral";
+type LookConstStructure = "structure";
+type LookConstFlag = "flag";
+type LookConstConstructionSite = "constructionSite";
+type LookConstNuke = "nuke";
+type LookConstTerrain = "terrain";
+
+declare var LOOK_CREEPS:             LookConstCreep;
+declare var LOOK_ENERGY:             LookConstEnergy;
+declare var LOOK_RESOURCES:          LookConstResource;
+declare var LOOK_SOURCES:            LookConstSource;
+declare var LOOK_MINERALS:           LookConstMineral;
+declare var LOOK_STRUCTURES:         LookConstStructure;
+declare var LOOK_FLAGS:              LookConstFlag;
+declare var LOOK_CONSTRUCTION_SITES: LookConstConstructionSite;
+declare var LOOK_NUKES:              LookConstNuke;
+declare var LOOK_TERRAIN:            LookConstTerrain;
+
+type BodypartConst = BodypartConstMove | BodypartConstWork | BodypartConstCarry | BodypartConstAttack | BodypartConstRangedAttack | BodypartConstTough | BodypartConstHeal | BodypartConstClaim;
+type BodypartConstMove = "move";
+type BodypartConstWork = "work";
+type BodypartConstCarry = "carry";
+type BodypartConstAttack = "attack";
+type BodypartConstRangedAttack = "ranged_attack";
+type BodypartConstTough = "tough";
+type BodypartConstHeal = "heal";
+type BodypartConstClaim = "claim";
+
+declare var MOVE: BodypartConstMove;
+declare var WORK: BodypartConstWork;
+declare var CARRY: BodypartConstCarry;
+declare var ATTACK: BodypartConstAttack;
+declare var RANGED_ATTACK: BodypartConstRangedAttack;
+declare var TOUGH: BodypartConstTough;
+declare var HEAL: BodypartConstHeal;
+declare var CLAIM: BodypartConstClaim;
+declare var BODYPARTS_ALL: BodypartConst[];
+
+type StructureConst =
+    StructureConstSpawn
+    | StructureConstExtension
+    | StructureConstRoad
+    | StructureConstWall
+    | StructureConstRampart
+    | StructureConstKeeperLair
+    | StructureConstPortal
+    | StructureConstController
+    | StructureConstLink
+    | StructureConstStorage
+    | StructureConstTower
+    | StructureConstObserver
+    | StructureConstPowerBank
+    | StructureConstPowerSpawn
+    | StructureConstExtractor
+    | StructureConstLab
+    | StructureConstTerminal
+    | StructureConstContainer
+    | StructureConstNuker
+;
+type StructureConstSpawn = "spawn";
+type StructureConstExtension = "extension";
+type StructureConstRoad = "road";
+type StructureConstWall = "constructedWall";
+type StructureConstRampart = "rampart";
+type StructureConstKeeperLair = "keeperLair";
+type StructureConstPortal = "portal";
+type StructureConstController = "controller";
+type StructureConstLink = "link";
+type StructureConstStorage = "storage";
+type StructureConstTower = "tower";
+type StructureConstObserver = "observer";
+type StructureConstPowerBank = "powerBank";
+type StructureConstPowerSpawn = "powerSpawn";
+type StructureConstExtractor = "extractor";
+type StructureConstLab = "lab";
+type StructureConstTerminal = "terminal";
+type StructureConstContainer = "container";
+type StructureConstNuker = "nuker";
+
+declare var STRUCTURE_SPAWN: StructureConstSpawn;
+declare var STRUCTURE_EXTENSION: StructureConstExtension;
+declare var STRUCTURE_ROAD: StructureConstRoad;
+declare var STRUCTURE_WALL: StructureConstWall;
+declare var STRUCTURE_RAMPART: StructureConstRampart;
+declare var STRUCTURE_KEEPER_LAIR: StructureConstKeeperLair;
+declare var STRUCTURE_PORTAL: StructureConstPortal;
+declare var STRUCTURE_CONTROLLER: StructureConstController;
+declare var STRUCTURE_LINK: StructureConstLink;
+declare var STRUCTURE_STORAGE: StructureConstStorage;
+declare var STRUCTURE_TOWER: StructureConstTower;
+declare var STRUCTURE_OBSERVER: StructureConstObserver;
+declare var STRUCTURE_POWER_BANK: StructureConstPowerBank;
+declare var STRUCTURE_POWER_SPAWN: StructureConstPowerSpawn;
+declare var STRUCTURE_EXTRACTOR: StructureConstExtractor;
+declare var STRUCTURE_LAB: StructureConstLab;
+declare var STRUCTURE_TERMINAL: StructureConstTerminal;
+declare var STRUCTURE_CONTAINER: StructureConstContainer;
+declare var STRUCTURE_NUKER: StructureConstNuker;
+
+type ObjectConst = StructureConst | "creep" | "wall";
+
+type ResourceConst =
+    ResourceConstEnergy
+    | ResourceConstPower
+    | ResourceConstH
+    | ResourceConstO
+    | ResourceConstU
+    | ResourceConstL
+    | ResourceConstK
+    | ResourceConstZ
+    | ResourceConstX
+    | ResourceConstG
+    | ResourceConstOH
+    | ResourceConstZK
+    | ResourceConstUL
+    | ResourceConstUH
+    | ResourceConstUO
+    | ResourceConstKH
+    | ResourceConstKO
+    | ResourceConstLH
+    | ResourceConstLO
+    | ResourceConstZH
+    | ResourceConstZO
+    | ResourceConstGH
+    | ResourceConstGO
+    | ResourceConstUH2O
+    | ResourceConstUHO2
+    | ResourceConstKH2O
+    | ResourceConstKHO2
+    | ResourceConstLH2O
+    | ResourceConstLHO2
+    | ResourceConstZH2O
+    | ResourceConstZHO2
+    | ResourceConstGH2O
+    | ResourceConstGHO2
+    | ResourceConstXUH2O
+    | ResourceConstXUHO2
+    | ResourceConstXKH2O
+    | ResourceConstXKHO2
+    | ResourceConstXLH2O
+    | ResourceConstXLHO2
+    | ResourceConstXZH2O
+    | ResourceConstXZHO2
+    | ResourceConstXGH2O
+    | ResourceConstXGHO2
+;
+type ResourceConstEnergy = "energy";
+type ResourceConstPower = "power";
+type ResourceConstH = "H";
+type ResourceConstO = "O";
+type ResourceConstU = "U";
+type ResourceConstL = "L";
+type ResourceConstK = "K";
+type ResourceConstZ = "Z";
+type ResourceConstX = "X";
+type ResourceConstG = "G";
+type ResourceConstOH = "OH";
+type ResourceConstZK = "ZK";
+type ResourceConstUL = "UL";
+type ResourceConstUH = "UH";
+type ResourceConstUO = "UO";
+type ResourceConstKH = "KH";
+type ResourceConstKO = "KO";
+type ResourceConstLH = "LH";
+type ResourceConstLO = "LO";
+type ResourceConstZH = "ZH";
+type ResourceConstZO = "ZO";
+type ResourceConstGH = "GH";
+type ResourceConstGO = "GO";
+type ResourceConstUH2O = "UH2O";
+type ResourceConstUHO2 = "UHO2";
+type ResourceConstKH2O = "KH2O";
+type ResourceConstKHO2 = "KHO2";
+type ResourceConstLH2O = "LH2O";
+type ResourceConstLHO2 = "LHO2";
+type ResourceConstZH2O = "ZH2O";
+type ResourceConstZHO2 = "ZHO2";
+type ResourceConstGH2O = "GH2O";
+type ResourceConstGHO2 = "GHO2";
+type ResourceConstXUH2O = "XUH2O";
+type ResourceConstXUHO2 = "XUHO2";
+type ResourceConstXKH2O = "XKH2O";
+type ResourceConstXKHO2 = "XKHO2";
+type ResourceConstXLH2O = "XLH2O";
+type ResourceConstXLHO2 = "XLHO2";
+type ResourceConstXZH2O = "XZH2O";
+type ResourceConstXZHO2 = "XZHO2";
+type ResourceConstXGH2O = "XGH2O";
+type ResourceConstXGHO2 = "XGHO2";
+
+type SubscriptionTokenConst = "token";
+
+declare var RESOURCE_ENERGY: ResourceConstEnergy;
+declare var RESOURCE_POWER: ResourceConstPower;
+declare var RESOURCE_HYDROGEN: ResourceConstH;
+declare var RESOURCE_OXYGEN: ResourceConstO;
+declare var RESOURCE_UTRIUM: ResourceConstU;
+declare var RESOURCE_LEMERGIUM: ResourceConstL;
+declare var RESOURCE_KEANIUM: ResourceConstK;
+declare var RESOURCE_ZYNTHIUM: ResourceConstZ;
+declare var RESOURCE_CATALYST: ResourceConstX;
+declare var RESOURCE_GHODIUM: ResourceConstG;
+declare var RESOURCE_HYDROXIDE: ResourceConstOH;
+declare var RESOURCE_ZYNTHIUM_KEANITE: ResourceConstZK;
+declare var RESOURCE_UTRIUM_LEMERGITE: ResourceConstUL;
+declare var RESOURCE_UTRIUM_HYDRIDE: ResourceConstUH;
+declare var RESOURCE_UTRIUM_OXIDE: ResourceConstUO;
+declare var RESOURCE_KEANIUM_HYDRIDE: ResourceConstKH;
+declare var RESOURCE_KEANIUM_OXIDE: ResourceConstKO;
+declare var RESOURCE_LEMERGIUM_HYDRIDE: ResourceConstLH;
+declare var RESOURCE_LEMERGIUM_OXIDE: ResourceConstLO;
+declare var RESOURCE_ZYNTHIUM_HYDRIDE: ResourceConstZH;
+declare var RESOURCE_ZYNTHIUM_OXIDE: ResourceConstZO;
+declare var RESOURCE_GHODIUM_HYDRIDE: ResourceConstGH;
+declare var RESOURCE_GHODIUM_OXIDE: ResourceConstGO;
+declare var RESOURCE_UTRIUM_ACID: ResourceConstUH2O;
+declare var RESOURCE_UTRIUM_ALKALIDE: ResourceConstUHO2;
+declare var RESOURCE_KEANIUM_ACID: ResourceConstKH2O;
+declare var RESOURCE_KEANIUM_ALKALIDE: ResourceConstKHO2;
+declare var RESOURCE_LEMERGIUM_ACID: ResourceConstLH2O;
+declare var RESOURCE_LEMERGIUM_ALKALIDE: ResourceConstLHO2;
+declare var RESOURCE_ZYNTHIUM_ACID: ResourceConstZH2O;
+declare var RESOURCE_ZYNTHIUM_ALKALIDE: ResourceConstZHO2;
+declare var RESOURCE_GHODIUM_ACID: ResourceConstGH2O;
+declare var RESOURCE_GHODIUM_ALKALIDE: ResourceConstGHO2;
+declare var RESOURCE_CATALYZED_UTRIUM_ACID: ResourceConstXUH2O;
+declare var RESOURCE_CATALYZED_UTRIUM_ALKALIDE: ResourceConstXUHO2;
+declare var RESOURCE_CATALYZED_KEANIUM_ACID: ResourceConstXKH2O;
+declare var RESOURCE_CATALYZED_KEANIUM_ALKALIDE: ResourceConstXKHO2;
+declare var RESOURCE_CATALYZED_LEMERGIUM_ACID: ResourceConstXLH2O;
+declare var RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE: ResourceConstXLHO2;
+declare var RESOURCE_CATALYZED_ZYNTHIUM_ACID: ResourceConstXZH2O;
+declare var RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE: ResourceConstXZHO2;
+declare var RESOURCE_CATALYZED_GHODIUM_ACID: ResourceConstXGH2O;
+declare var RESOURCE_CATALYZED_GHODIUM_ALKALIDE: ResourceConstXGHO2;
+declare var RESOURCES_ALL: ResourceConst[];
+
+type TerrainConst = "plain" | "swamp" | "wall";
 
 declare var CREEP_SPAWN_TIME: number;
 declare var CREEP_LIFE_TIME: number;
 declare var CREEP_CLAIM_LIFE_TIME: number;
 declare var CREEP_CORPSE_RATE: number;
 
-declare var OBSTACLE_OBJECT_TYPES: string[];
+declare var OBSTACLE_OBJECT_TYPES: ObjectConst[];
 
 declare var ENERGY_REGEN_TIME: number;
 declare var ENERGY_DECAY: number;
@@ -131,8 +475,6 @@ declare var BODYPART_COST: {
     tough: number;
     claim: number;
 };
-declare var BODYPARTS_ALL: string[];
-
 
 declare var CARRY_CAPACITY: number;
 declare var HARVEST_POWER: number;
@@ -146,15 +488,6 @@ declare var RANGED_ATTACK_POWER: number;
 declare var HEAL_POWER: number;
 declare var RANGED_HEAL_POWER: number;
 declare var DISMANTLE_COST: number;
-
-declare var MOVE: string;
-declare var WORK: string;
-declare var CARRY: string;
-declare var ATTACK: string;
-declare var RANGED_ATTACK: string;
-declare var TOUGH: string;
-declare var HEAL: string;
-declare var CLAIM: string;
 
 declare var CONSTRUCTION_COST: {
     spawn: number;
@@ -175,72 +508,7 @@ declare var CONSTRUCTION_COST: {
 
 declare var CONSTRUCTION_COST_ROAD_SWAMP_RATIO: number;
 
-declare var STRUCTURE_EXTENSION: string;
-declare var STRUCTURE_RAMPART: string;
-declare var STRUCTURE_ROAD: string;
-declare var STRUCTURE_SPAWN: string;
-declare var STRUCTURE_LINK: string;
-declare var STRUCTURE_WALL: string;
-declare var STRUCTURE_KEEPER_LAIR: string;
-declare var STRUCTURE_CONTROLLER: string;
-declare var STRUCTURE_STORAGE: string;
-declare var STRUCTURE_TOWER: string;
-declare var STRUCTURE_OBSERVER: string;
-declare var STRUCTURE_POWER_BANK: string;
-declare var STRUCTURE_POWER_SPAWN: string;
-declare var STRUCTURE_EXTRACTOR: string;
-declare var STRUCTURE_LAB: string;
-declare var STRUCTURE_TERMINAL: string;
-declare var STRUCTURE_CONTAINER: string;
-declare var STRUCTURE_NUKER: string;
-declare var STRUCTURE_PORTAL: string;
-
-declare var RESOURCE_ENERGY: string;
-declare var RESOURCE_POWER: string;
-declare var RESOURCE_UTRIUM: string;
-declare var RESOURCE_LEMERGIUM: string;
-declare var RESOURCE_KEANIUM: string;
-declare var RESOURCE_GHODIUM: string;
-declare var RESOURCE_ZYNTHIUM: string;
-declare var RESOURCE_OXYGEN: string;
-declare var RESOURCE_HYDROGEN: string;
-declare var RESOURCE_CATALYST: string;
-declare var RESOURCE_HYDROXIDE: string;
-declare var RESOURCE_ZYNTHIUM_KEANITE: string;
-declare var RESOURCE_UTRIUM_LEMERGITE: string;
-declare var RESOURCE_UTRIUM_HYDRIDE: string;
-declare var RESOURCE_UTRIUM_OXIDE: string;
-declare var RESOURCE_KEANIUM_HYDRIDE: string;
-declare var RESOURCE_KEANIUM_OXIDE: string;
-declare var RESOURCE_LEMERGIUM_HYDRIDE: string;
-declare var RESOURCE_LEMERGIUM_OXIDE: string;
-declare var RESOURCE_ZYNTHIUM_HYDRIDE: string;
-declare var RESOURCE_ZYNTHIUM_OXIDE: string;
-declare var RESOURCE_GHODIUM_HYDRIDE: string;
-declare var RESOURCE_GHODIUM_OXIDE: string;
-declare var RESOURCE_UTRIUM_ACID: string;
-declare var RESOURCE_UTRIUM_ALKALIDE: string;
-declare var RESOURCE_KEANIUM_ACID: string;
-declare var RESOURCE_KEANIUM_ALKALIDE: string;
-declare var RESOURCE_LEMERGIUM_ACID: string;
-declare var RESOURCE_LEMERGIUM_ALKALIDE: string;
-declare var RESOURCE_ZYNTHIUM_ACID: string;
-declare var RESOURCE_ZYNTHIUM_ALKALIDE: string;
-declare var RESOURCE_GHODIUM_ACID: string;
-declare var RESOURCE_GHODIUM_ALKALIDE: string;
-declare var RESOURCE_CATALYZED_UTRIUM_ACID: string;
-declare var RESOURCE_CATALYZED_UTRIUM_ALKALIDE: string;
-declare var RESOURCE_CATALYZED_KEANIUM_ACID: string;
-declare var RESOURCE_CATALYZED_KEANIUM_ALKALIDE: string;
-declare var RESOURCE_CATALYZED_LEMERGIUM_ACID: string;
-declare var RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE: string;
-declare var RESOURCE_CATALYZED_ZYNTHIUM_ACID: string;
-declare var RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE: string;
-declare var RESOURCE_CATALYZED_GHODIUM_ACID: string;
-declare var RESOURCE_CATALYZED_GHODIUM_ALKALIDE: string;
-declare var RESOURCES_ALL: string[];
-
-declare var SUBSCRIPTION_TOKEN: string;
+declare var SUBSCRIPTION_TOKEN: SubscriptionTokenConst;
 
 declare var CONTROLLER_LEVELS: {[level: number]: number};
 declare var CONTROLLER_STRUCTURES: {[structure: string]: {[level: number]: number}};
@@ -289,10 +557,16 @@ declare var GCL_POW: number;
 declare var GCL_MULTIPLY: number;
 declare var GCL_NOVICE: number;
 
-declare var MODE_SIMULATION: string;
-declare var MODE_SURVIVAL: string;
-declare var MODE_WORLD: string;
-declare var MODE_ARENA: string;
+type ModeConst = ModeConstSimulation | ModeConstSurvival | ModeConstWorld | ModeConstArena;
+type ModeConstSimulation = "simulation";
+type ModeConstSurvival = "survival";
+type ModeConstWorld = "world";
+type ModeConstArena = "arena";
+
+declare var MODE_SIMULATION: ModeConstSimulation;
+declare var MODE_SURVIVAL: ModeConstSurvival;
+declare var MODE_WORLD: ModeConstWorld;
+declare var MODE_ARENA: ModeConstArena;
 
 declare var TERRAIN_MASK_WALL: number;
 declare var TERRAIN_MASK_SWAMP: number;
@@ -338,7 +612,7 @@ declare var NUKE_DAMAGE: {
 
 declare var REACTIONS: {
     [reagent: string]: {
-        [reagent: string]: string
+        [reagent: string]: ResourceConst
     }
 }
 
@@ -350,16 +624,9 @@ declare var BOOSTS: {
     }
 }
 
-declare var LOOK_CREEPS: string;
-declare var LOOK_ENERGY: string;
-declare var LOOK_RESOURCES: string;
-declare var LOOK_SOURCES: string;
-declare var LOOK_MINERALS: string;
-declare var LOOK_STRUCTURES: string;
-declare var LOOK_FLAGS: string;
-declare var LOOK_CONSTRUCTION_SITES: string;
-declare var LOOK_NUKES: string;
-declare var LOOK_TERRAIN: string;
+type OrderConst = OrderConstSell | OrderConstBuy;
+type OrderConstSell = "sell";
+type OrderConstBuy = "buy";
 
-declare var ORDER_SELL: string;
-declare var ORDER_BUY: string;
+declare var ORDER_SELL: OrderConstSell;
+declare var ORDER_BUY: OrderConstBuy;

--- a/src/construction-site.ts
+++ b/src/construction-site.ts
@@ -2,6 +2,8 @@
  * A site of a structure which is currently under construction.
  */
 interface ConstructionSite extends RoomObject {
+    readonly prototype: ConstructionSite;
+    
     /**
      * A unique object identificator. You can use Game.getObjectById method to retrieve an object instance by its id.
      */
@@ -33,8 +35,7 @@ interface ConstructionSite extends RoomObject {
     remove(): number;
 }
 
-interface ConstructionSiteConstructor {
-    new (id: string): ConstructionSite;
+interface ConstructionSiteConstructor extends _Constructor<ConstructionSite>, _ConstructorById<ConstructionSite> {
 }
 
 declare const ConstructionSite: ConstructionSiteConstructor;

--- a/src/construction-site.ts
+++ b/src/construction-site.ts
@@ -25,14 +25,14 @@ interface ConstructionSite extends RoomObject {
      */
     progressTotal: number;
     /**
-     * One of the following constants: STRUCTURE_EXTENSION, STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_SPAWN, STRUCTURE_WALL, STRUCTURE_LINK
+     * One of the STRUCTURE_* constants.
      */
-    structureType: string;
+    structureType: StructureConst;
     /**
      * Remove the construction site.
      * @returns Result Code: OK, ERR_NOT_OWNER
      */
-    remove(): number;
+    remove(): ReturnConstOk | ReturnConstErrNotOwner;
 }
 
 interface ConstructionSiteConstructor extends _Constructor<ConstructionSite>, _ConstructorById<ConstructionSite> {

--- a/src/construction-site.ts
+++ b/src/construction-site.ts
@@ -1,7 +1,7 @@
 /**
  * A site of a structure which is currently under construction.
  */
-declare class ConstructionSite extends RoomObject{
+interface ConstructionSite extends RoomObject {
     /**
      * A unique object identificator. You can use Game.getObjectById method to retrieve an object instance by its id.
      */
@@ -32,3 +32,9 @@ declare class ConstructionSite extends RoomObject{
      */
     remove(): number;
 }
+
+interface ConstructionSiteConstructor {
+    new (id: string): ConstructionSite;
+}
+
+declare const ConstructionSite: ConstructionSiteConstructor;

--- a/src/core.ts
+++ b/src/core.ts
@@ -13,7 +13,6 @@ type Rampart = StructureRampart;
 type Terminal = StructureTerminal;
 type Container = StructureContainer;
 type Tower = StructureTower;
-interface Storage extends StructureStorage {
-  readonly prototype: StructureStorage;
-}
-
+type Spawn = StructureSpawn;//Legacy Alias
+declare const Spawn: StructureSpawnConstructor;
+interface Storage extends StructureStorage { }//Legacy Alias

--- a/src/core.ts
+++ b/src/core.ts
@@ -14,5 +14,6 @@ type Terminal = StructureTerminal;
 type Container = StructureContainer;
 type Tower = StructureTower;
 interface Storage extends StructureStorage {
+  readonly prototype: StructureStorage;
 }
 

--- a/src/creep.ts
+++ b/src/creep.ts
@@ -2,7 +2,7 @@
 /**
  * Creeps are your units. Creeps can move, harvest energy, construct structures, attack another creeps, and perform other actions. Each creep consists of up to 50 body parts with the following possible types:
  */
-declare class Creep extends RoomObject{
+interface Creep extends RoomObject {
     /**
      * An array describing the creep’s body. Each element contains the following properties:
      * type: string
@@ -207,3 +207,9 @@ declare class Creep extends RoomObject{
      */
     withdraw(target: Structure, resourceType: string, amount?: number): number;
 }
+
+interface CreepConstructor {
+    //No accessible constructor
+}
+
+declare const Creep: CreepConstructor;

--- a/src/creep.ts
+++ b/src/creep.ts
@@ -3,6 +3,8 @@
  * Creeps are your units. Creeps can move, harvest energy, construct structures, attack another creeps, and perform other actions. Each creep consists of up to 50 body parts with the following possible types:
  */
 interface Creep extends RoomObject {
+    readonly prototype: Creep;
+    
     /**
      * An array describing the creep’s body. Each element contains the following properties:
      * type: string
@@ -208,8 +210,7 @@ interface Creep extends RoomObject {
     withdraw(target: Structure, resourceType: string, amount?: number): number;
 }
 
-interface CreepConstructor {
-    //No accessible constructor
+interface CreepConstructor extends _Constructor<Creep>, _ConstructorById<Creep> {
 }
 
 declare const Creep: CreepConstructor;

--- a/src/creep.ts
+++ b/src/creep.ts
@@ -1,10 +1,15 @@
-// Updated 2016-02-05
+type StandardCreepReturn = ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrBusy | ReturnConstErrNoBodypart;
+type TargetCreepReturn = StandardCreepReturn | ReturnConstErrInvalidTarget | ReturnConstErrNotInRange;
 /**
  * Creeps are your units. Creeps can move, harvest energy, construct structures, attack another creeps, and perform other actions. Each creep consists of up to 50 body parts with the following possible types:
  */
 interface Creep extends RoomObject {
     readonly prototype: Creep;
-    
+    /**
+     * Room cannot be undefined for a Creep.
+     */
+
+    room: Room;
     /**
      * An array describing the creep’s body. Each element contains the following properties:
      * type: string
@@ -12,7 +17,7 @@ interface Creep extends RoomObject {
      * hits: number
      * The remaining amount of hit points of this body part.
      */
-    body: BodyPartDefinition[];
+    body: BodypartDefinition[];
     /**
      * An object with the creep's cargo contents:
      * energy: number
@@ -71,143 +76,143 @@ interface Creep extends RoomObject {
      * Attack another creep or structure in a short-ranged attack. Needs the ATTACK body part. If the target is inside a rampart, then the rampart is attacked instead. The target has to be at adjacent square to the creep. If the target is a creep with ATTACK body parts and is not inside a rampart, it will automatically hit back at the attacker.
      * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART
      */
-    attack(target: Creep|Spawn|Structure): number;
+    attack(target: Creep|Structure): TargetCreepReturn;
     /**
      * Decreases the controller's downgrade or reservation timer for 1 tick per every 5 CLAIM body parts (so the creep must have at least 5xCLAIM). The controller under attack cannot be upgraded for the next 1,000 ticks. The target has to be at adjacent square to the creep.
      * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART
      */
-    attackController(target: Structure): number;
+    attackController(target: StructureController): TargetCreepReturn;
     /**
      * Build a structure at the target construction site using carried energy. Needs WORK and CARRY body parts. The target has to be within 3 squares range of the creep.
      * @param target The target object to be attacked.
      * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_NOT_ENOUGH_RESOURCES, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART, ERR_RCL_NOT_ENOUGH
      */
-    build(target: ConstructionSite): number;
+    build(target: ConstructionSite): TargetCreepReturn | ReturnConstErrNotEnough | ReturnConstErrRCL;
     /**
      * Cancel the order given during the current game tick.
      * @param methodName The name of a creep's method to be cancelled.
      * @returns Result Code: OK, ERR_NOT_FOUND
      */
-    cancelOrder(methodName: string): number;
+    cancelOrder(methodName: string): ReturnConstOk | ReturnConstErrNotFound;
     /**
      * Requires the CLAIM body part. If applied to a neutral controller, claims it under your control. If applied to a hostile controller, decreases its downgrade or reservation timer depending on the CLAIM body parts count. The target has to be at adjacent square to the creep.
      * @param target The target controller object.
      * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_FULL, ERR_NOT_IN_RANGE, ERR_NO_BODYPART, ERR_GCL_NOT_ENOUGH
      */
-    claimController(target: Controller): number;
+    claimController(target: StructureController): TargetCreepReturn | ReturnConstErrFull | ReturnConstErrGCL;
     /**
      * Dismantles any (even hostile) structure returning 50% of the energy spent on its repair. Requires the WORK body part. If the creep has an empty CARRY body part, the energy is put into it; otherwise it is dropped on the ground. The target has to be at adjacent square to the creep.
      * @param target The target structure.
      */
-    dismantle(target: Spawn|Structure): number;
+    dismantle(target: Structure): TargetCreepReturn;
     /**
      * Drop this resource on the ground.
      * @param resourceType One of the RESOURCE_* constants.
      * @param amount The amount of resource units to be dropped. If omitted, all the available carried amount is used.
      */
-    drop(resourceType: string, amount?: number): number;
+    drop(resourceType: ResourceConst, amount?: number): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrBusy | ReturnConstErrNotEnough;
     /**
      * Get the quantity of live body parts of the given type. Fully damaged parts do not count.
      * @param type A body part type, one of the following body part constants: MOVE, WORK, CARRY, ATTACK, RANGED_ATTACK, HEAL, TOUGH, CLAIM
      */
-    getActiveBodyparts(type: string): number;
+    getActiveBodyparts(type: BodypartConst): number;
     /**
      * Harvest energy from the source. Needs the WORK body part. If the creep has an empty CARRY body part, the harvested energy is put into it; otherwise it is dropped on the ground. The target has to be at an adjacent square to the creep.
      * @param target The source object to be harvested.
      */
-    harvest(target: Source | Mineral): number;
+    harvest(target: Source | Mineral): TargetCreepReturn | ReturnConstErrNotFound | ReturnConstErrNotEnough;
     /**
      * Heal self or another creep. It will restore the target creep’s damaged body parts function and increase the hits counter. Needs the HEAL body part. The target has to be at adjacent square to the creep.
      * @param target The target creep object.
      */
-    heal(target: Creep): number;
+    heal(target: Creep): TargetCreepReturn;
     /**
      * Move the creep one square in the specified direction. Needs the MOVE body part.
      * @param direction
      */
-    move(direction: number) : number;
+    move(direction: DirConst) : StandardCreepReturn | ReturnConstErrTired;
     /**
      * Move the creep using the specified predefined path. Needs the MOVE body part.
      * @param path A path value as returned from Room.findPath or RoomPosition.findPathTo methods. Both array form and serialized string form are accepted.
      */
-    moveByPath(path: PathStep[] | RoomPosition[] | string): number;
+    moveByPath(path: PathStep[] | RoomPosition[] | string): StandardCreepReturn | ReturnConstErrNotFound | ReturnConstErrInvalidArgs | ReturnConstErrTired;
     /**
      * Find the optimal path to the target within the same room and move to it. A shorthand to consequent calls of pos.findPathTo() and move() methods. If the target is in another room, then the corresponding exit will be used as a target. Needs the MOVE body part.
      * @param x X position of the target in the room.
      * @param y Y position of the target in the room.
      * @param opts An object containing pathfinding options flags (see Room.findPath for more info) or one of the following: reusePath, serializeMemory, noPathFinding
      */
-    moveTo(x: number, y: number, opts?: MoveToOpts & FindPathOpts): number;
+    moveTo(x: number, y: number, opts?: MoveToOpts & FindPathOpts): StandardCreepReturn | ReturnConstErrTired | ReturnConstErrInvalidTarget | ReturnConstErrNoPath;
     /**
      * Find the optimal path to the target within the same room and move to it. A shorthand to consequent calls of pos.findPathTo() and move() methods. If the target is in another room, then the corresponding exit will be used as a target. Needs the MOVE body part.
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
      * @param opts An object containing pathfinding options flags (see Room.findPath for more info) or one of the following: reusePath, serializeMemory, noPathFinding
      */
-    moveTo(target: RoomPosition|{pos: RoomPosition}, opts?: MoveToOpts & FindPathOpts): number;
+    moveTo(target: RoomPosition|{pos: RoomPosition}, opts?: MoveToOpts & FindPathOpts): StandardCreepReturn | ReturnConstErrTired | ReturnConstErrInvalidTarget | ReturnConstErrNoPath;
     /**
      * Toggle auto notification when the creep is under attack. The notification will be sent to your account email. Turned on by default.
      * @param enabled Whether to enable notification or disable.
      */
-    notifyWhenAttacked(enabled: boolean): number;
+    notifyWhenAttacked(enabled: boolean): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrInvalidArgs;
     /**
      * Pick up an item (a dropped piece of energy). Needs the CARRY body part. The target has to be at adjacent square to the creep or at the same square.
      * @param target The target object to be picked up.
      */
-    pickup(target: Resource): number;
+    pickup(target: Resource): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrBusy | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrNotInRange;
     /**
      * A ranged attack against another creep or structure. Needs the RANGED_ATTACK body part. If the target is inside a rampart, the rampart is attacked instead. The target has to be within 3 squares range of the creep.
      * @param target The target object to be attacked.
      */
-    rangedAttack(target: Creep|Spawn|Structure): number;
+    rangedAttack(target: Creep|Structure): TargetCreepReturn;
     /**
      * Heal another creep at a distance. It will restore the target creep’s damaged body parts function and increase the hits counter. Needs the HEAL body part. The target has to be within 3 squares range of the creep.
      * @param target The target creep object.
      */
-    rangedHeal(target: Creep): number;
+    rangedHeal(target: Creep): TargetCreepReturn;
     /**
      * A ranged attack against all hostile creeps or structures within 3 squares range. Needs the RANGED_ATTACK body part. The attack power depends on the range to each target. Friendly units are not affected.
      */
-    rangedMassAttack(): number;
+    rangedMassAttack(): StandardCreepReturn;
     /**
      * Repair a damaged structure using carried energy. Needs the WORK and CARRY body parts. The target has to be within 3 squares range of the creep.
      * @param target he target structure to be repaired.
      */
-    repair(target: Spawn|Structure): number;
+    repair(target: Structure): TargetCreepReturn | ReturnConstErrNotEnough;
     /**
      * Temporarily block a neutral controller from claiming by other players. Each tick, this command increases the counter of the period during which the controller is unavailable by 1 tick per each CLAIM body part. The maximum reservation period to maintain is 5,000 ticks. The target has to be at adjacent square to the creep....
      * @param target The target controller object to be reserved.
      * @return Result code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART
      */
-    reserveController(target: Controller): number;
+    reserveController(target: Controller): TargetCreepReturn;
     /**
      * Display a visual speech balloon above the creep with the specified message. The message will disappear after a few seconds. Useful for debugging purposes. Only the creep's owner can see the speech message.
      * @param message The message to be displayed. Maximum length is 10 characters.
      * @param set to 'true' to allow other players to see this message. Default is 'false'.
      */
-    say(message: string, toPublic?: boolean): number;
+    say(message: string, toPublic?: boolean): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrBusy;
     /**
      * Kill the creep immediately.
      */
-    suicide(): number;
+    suicide(): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrBusy;
     /**
      * Transfer resource from the creep to another object. The target has to be at adjacent square to the creep.
      * @param target The target object.
      * @param resourceType One of the RESOURCE_* constants
      * @param amount The amount of resources to be transferred. If omitted, all the available carried amount is used.
      */
-    transfer(target: Creep|Spawn|Structure, resourceType: string, amount?: number): number;
+    transfer(target: Creep|Structure, resourceType: ResourceConst, amount?: number): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrBusy | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrNotInRange | ReturnConstErrInvalidArgs;
     /**
      * Upgrade your controller to the next level using carried energy. Upgrading controllers raises your Global Control Level in parallel. Needs WORK and CARRY body parts. The target has to be at adjacent square to the creep. A fully upgraded level 8 controller can't be upgraded with the power over 15 energy units per tick regardless of creeps power. The cumulative effect of all the creeps performing upgradeController in the current tick is taken into account.
      * @param target The target controller object to be upgraded.
      */
-    upgradeController(target: Controller): number;
+    upgradeController(target: Controller): TargetCreepReturn | ReturnConstErrNotEnough;
     /**
      * Withdraw resources from a structure. The target has to be at adjacent square to the creep. Multiple creeps can withdraw from the same structure in the same tick. Your creeps can withdraw resources from hostile structures as well, in case if there is no hostile rampart on top of it.
      * @param target The target object.
      * @param resourceType The target One of the RESOURCE_* constants..
      * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
      */
-    withdraw(target: Structure, resourceType: string, amount?: number): number;
+    withdraw(target: Structure, resourceType: ResourceConst, amount?: number): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrBusy | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrNotInRange | ReturnConstErrInvalidArgs;
 }
 
 interface CreepConstructor extends _Constructor<Creep>, _ConstructorById<Creep> {

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -1,7 +1,7 @@
 /**
  * A flag. Flags can be used to mark particular spots in a room. Flags are visible to their owners only.
  */
-declare class Flag extends RoomObject{
+interface Flag extends RoomObject {
     /**
      * Flag color. One of the following constants: COLOR_WHITE, COLOR_GREY, COLOR_RED, COLOR_PURPLE, COLOR_BLUE, COLOR_CYAN, COLOR_GREEN, COLOR_YELLOW, COLOR_ORANGE, COLOR_BROWN
      */
@@ -44,3 +44,9 @@ declare class Flag extends RoomObject{
      */
     setPosition(pos: RoomPosition|{pos: RoomPosition}): number;
 }
+
+interface FlagConstructor {
+    //No accessible constructor
+}
+
+declare const Flag: FlagConstructor;

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -3,11 +3,10 @@
  */
 interface Flag extends RoomObject {
     readonly prototype: Flag;
-    
     /**
      * Flag color. One of the following constants: COLOR_WHITE, COLOR_GREY, COLOR_RED, COLOR_PURPLE, COLOR_BLUE, COLOR_CYAN, COLOR_GREEN, COLOR_YELLOW, COLOR_ORANGE, COLOR_BROWN
      */
-    color: number;
+    color: ColorConst;
     /**
      * A shorthand to Memory.flags[flag.name]. You can use it for quick access the flag's specific memory data object.
      */
@@ -19,37 +18,37 @@ interface Flag extends RoomObject {
     /**
      * Flag secondary color. One of the COLOR_* constants.
      */
-    secondaryColor: number;
+    secondaryColor: ColorConst;
     /**
      * Remove the flag.
      * @returns Result Code: OK
      */
-    remove(): number;
+    remove(): ReturnConstOk;
     /**
      * Set new color of the flag.
      * @param color One of the following constants: COLOR_WHITE, COLOR_GREY, COLOR_RED, COLOR_PURPLE, COLOR_BLUE, COLOR_CYAN, COLOR_GREEN, COLOR_YELLOW, COLOR_ORANGE, COLOR_BROWN
      * @parma secondaryColor Secondary color of the flag. One of the COLOR_* constants.
      * @returns Result Code: OK, ERR_INVALID_ARGS
      */
-    setColor(color: number, secondaryColor?: number): number;
+    setColor(color: ColorConst, secondaryColor?: ColorConst): ReturnConstOk | ReturnConstErrInvalidArgs;
     /**
      * Set new position of the flag.
      * @param x The X position in the room.
      * @param y The Y position in the room.
      * @returns Result Code: OK, ERR_INVALID_TARGET
      */
-    setPosition(x: number,y: number): number;
+    setPosition(x: number,y: number): ReturnConstOk | ReturnConstErrInvalidTarget;
     /**
      * Set new position of the flag.
      * @param pos Can be a RoomPosition object or any object containing RoomPosition.
      * @returns Result Code: OK, ERR_INVALID_TARGET
      */
-    setPosition(pos: RoomPosition|{pos: RoomPosition}): number;
+    setPosition(pos: RoomPosition|{pos: RoomPosition}): ReturnConstOk | ReturnConstErrInvalidTarget;
 }
 
 interface FlagConstructor extends _Constructor<Flag> {
-    new (name: string, color: number, secondaryColor: number, roomName: string, x: number, y: number): Flag;
-    (name: string, color: number, secondaryColor: number, roomName: string, x: number, y: number): Flag;
+    new (name: string, color: ColorConst, secondaryColor: ColorConst, roomName: string, x: number, y: number): Flag;
+    (name: string, color: ColorConst, secondaryColor: ColorConst, roomName: string, x: number, y: number): Flag;
 }
 
 declare const Flag: FlagConstructor;

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -2,6 +2,8 @@
  * A flag. Flags can be used to mark particular spots in a room. Flags are visible to their owners only.
  */
 interface Flag extends RoomObject {
+    readonly prototype: Flag;
+    
     /**
      * Flag color. One of the following constants: COLOR_WHITE, COLOR_GREY, COLOR_RED, COLOR_PURPLE, COLOR_BLUE, COLOR_CYAN, COLOR_GREEN, COLOR_YELLOW, COLOR_ORANGE, COLOR_BROWN
      */
@@ -22,7 +24,7 @@ interface Flag extends RoomObject {
      * Remove the flag.
      * @returns Result Code: OK
      */
-    remove(): void;
+    remove(): number;
     /**
      * Set new color of the flag.
      * @param color One of the following constants: COLOR_WHITE, COLOR_GREY, COLOR_RED, COLOR_PURPLE, COLOR_BLUE, COLOR_CYAN, COLOR_GREEN, COLOR_YELLOW, COLOR_ORANGE, COLOR_BROWN
@@ -45,8 +47,9 @@ interface Flag extends RoomObject {
     setPosition(pos: RoomPosition|{pos: RoomPosition}): number;
 }
 
-interface FlagConstructor {
-    //No accessible constructor
+interface FlagConstructor extends _Constructor<Flag> {
+    new (name: string, color: number, secondaryColor: number, roomName: string, x: number, y: number): Flag;
+    (name: string, color: number, secondaryColor: number, roomName: string, x: number, y: number): Flag;
 }
 
 declare const Flag: FlagConstructor;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -18,15 +18,15 @@ interface CPU {
 /**
  * An array describing the creep’s body. Each element contains the following properties:
  */
-interface BodyPartDefinition {
+interface BodypartDefinition {
     /**
      * If the body part is boosted, this property specifies the mineral type which is used for boosting. One of the RESOURCE_* constants.
      */
-    boost: string;
+    boost: ResourceConst;
     /**
      * One of the body part types constants.
      */
-    type: string;
+    type: BodypartConst;
     /**
      * The remaining amount of hit points of this body part.
      */
@@ -41,17 +41,17 @@ interface ReservationDefinition {
 }
 interface StoreDefinition {
     [resource: string]: number | undefined;
-    energy?: number;
+    energy: number;
     power?: number;
 }
 
 interface LookAtResultWithPos {
     x: number;
     y: number;
-    type: string;
+    type: LookConst;
     constructionSite?: ConstructionSite;
     creep?: Creep;
-    terrain?: string;
+    terrain?: TerrainConst;
     structure?: Structure;
     flag?: Flag;
     energy?: Resource;
@@ -59,6 +59,7 @@ interface LookAtResultWithPos {
     source?: Source;
     mineral?: Mineral;
     resource? : Resource;
+    [key: string]: any;
 }
 interface LookAtResult {
     type: string;
@@ -69,9 +70,10 @@ interface LookAtResult {
     flag?: Flag;
     source?: Source;
     structure?: Structure;
-    terrain?: string;
+    terrain?: TerrainConst;
     mineral?: Mineral;
     resource?: Resource;
+    [key: string]: any;
 }
 
 
@@ -167,12 +169,33 @@ interface MoveToOpts {
     noPathFinding?: boolean;
 }
 
+interface FindRouteOpts {
+    /**
+     * This callback accepts two arguments: function(roomName, fromRoomName). It can be used to calculate the cost of entering that
+     * room. You can use this to do things like prioritize your own rooms, or avoid some rooms. You can return a floating point cost
+     * or Infinity to block the room.
+     */
+    routeCallback?(roomName: string, fromRoomName: string): number;
+}
+
+interface RouteStep {
+    exit: FindConstExit;
+    room: string;
+}
+
 interface PathStep {
     x: number;
     dx: number;
     y: number;
     dy: number;
     direction: number;
+}
+
+type PathFinderGoal = RoomPosition | PathFinderGoalObject;
+
+interface PathFinderGoalObject {
+    pos: RoomPosition;
+    range?: number;
 }
 
 /**
@@ -201,3 +224,5 @@ interface _ConstructorById<T> extends _Constructor<T> {
     new (id: string): T;
     (id: string): T;
 }
+
+type PathfindingAlgorithm = "astar" | "dijkstra";

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -190,3 +190,12 @@ interface SurvivalGameInfo {
      */
     wave: number;
 }
+
+interface _Constructor<T> {
+    readonly prototype: T;
+}
+
+interface _ConstructorById<T> extends _Constructor<T> {
+    new (id: string): T;
+    (id: string): T;
+}

--- a/src/map.ts
+++ b/src/map.ts
@@ -8,7 +8,7 @@ interface GameMap {
      * @param roomName The room name.
      * @returns The exits information or null if the room not found.
      */
-    describeExits(roomName: string): { "1": string, "3": string, "5": string, "7": string };
+    describeExits(roomName: string): { "1"?: string, "3"?: string, "5"?: string, "7"?: string } | null;
     /**
      * Find the exit direction from the given room en route to another room.
      * @param fromRoom Start room name or room object.
@@ -18,17 +18,14 @@ interface GameMap {
      * Or one of the following Result codes:
      * ERR_NO_PATH, ERR_INVALID_ARGS
      */
-    findExit(fromRoom: string | Room, toRoom: string | Room): string | number;
+    findExit(fromRoom: string | Room, toRoom: string | Room, opts?: FindRouteOpts): FindConstExit | ReturnConstErrNoPath | ReturnConstErrInvalidArgs;
     /**
      * Find route from the given room to another room.
      * @param fromRoom Start room name or room object.
      * @param toRoom Finish room name or room object.
      * @returns the route array or ERR_NO_PATH code
      */
-    findRoute(fromRoom: string | Room, toRoom: string | Room, opts?: { routeCallback: { (roomName: string, fromRoomName: string): any } }): {
-        exit: string;
-        room: string;
-    }[] | number;
+    findRoute(fromRoom: string | Room, toRoom: string | Room, opts?: FindRouteOpts): RouteStep[] | ReturnConstErrNoPath;
     /**
      * Get the linear distance (in rooms) between two rooms. You can use this function to estimate the energy cost of
      * sending resources through terminals, or using observers and nukes.
@@ -46,12 +43,12 @@ interface GameMap {
      * @param y Y position in the room.
      * @param roomName The room name.
      */
-    getTerrainAt(x: number, y: number, roomName: string): string;
+    getTerrainAt(x: number, y: number, roomName: string): TerrainConst;
     /**
      * Get terrain type at the specified room position. This method works for any room in the world even if you have no access to it.
      * @param pos The position object.
      */
-    getTerrainAt(pos: RoomPosition): string;
+    getTerrainAt(pos: RoomPosition): TerrainConst;
 
     /**
      * Check if the room with the given name is protected by temporary "newbie" walls.

--- a/src/map.ts
+++ b/src/map.ts
@@ -2,13 +2,13 @@
 /**
  * A global object representing world map. Use it to navigate between rooms. The object is accessible via Game.map property.
  */
-declare class GameMap {
+interface GameMap {
     /**
      * List all exits available from the room with the given name.
      * @param roomName The room name.
      * @returns The exits information or null if the room not found.
      */
-    describeExits(roomName: string): {"1": string, "3": string, "5": string, "7": string};
+    describeExits(roomName: string): { "1": string, "3": string, "5": string, "7": string };
     /**
      * Find the exit direction from the given room en route to another room.
      * @param fromRoom Start room name or room object.
@@ -18,7 +18,7 @@ declare class GameMap {
      * Or one of the following Result codes:
      * ERR_NO_PATH, ERR_INVALID_ARGS
      */
-    findExit(fromRoom: string|Room, toRoom: string|Room): string|number;
+    findExit(fromRoom: string | Room, toRoom: string | Room): string | number;
     /**
      * Find route from the given room to another room.
      * @param fromRoom Start room name or room object.
@@ -60,3 +60,5 @@ declare class GameMap {
      */
     isRoomProtected(roomName: string): boolean;
 }
+
+//No static is available

--- a/src/market.ts
+++ b/src/market.ts
@@ -2,7 +2,7 @@
  * A global object representing the in-game market. You can use this object to track resource transactions to/from your
  * terminals, and your buy/sell orders. The object is accessible via the singleton Game.market property.
  */
-declare class Market {
+interface Market {
     /**
      * Your current credits balance.
      */
@@ -45,6 +45,8 @@ declare class Market {
      */
     getAllOrders(filter?: OrderFilter | ((o: Order) => boolean)): Order[];
 }
+
+//No static is available
 
 interface Transaction {
     transactionId: string;

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,4 +1,3 @@
-// Updated 2016-02-05
 interface Memory {
     [name: string]: any;
     creeps: {[name: string]: any};

--- a/src/mineral.ts
+++ b/src/mineral.ts
@@ -1,11 +1,11 @@
 /**
  * A mineral deposit object. Can be harvested by creeps with a WORK body part using the extractor structure.
  */
-interface Mineral extends RoomObject{
+interface Mineral extends RoomObject {
     /**
      * The prototype is stored in the Mineral.prototype global object. You can use it to extend game objects behaviour globally.
      */
-    prototype: Mineral;
+    readonly prototype: Mineral;
 
     /**
      * The remaining amount of resources.
@@ -25,3 +25,8 @@ interface Mineral extends RoomObject{
     ticksToRegeneration: number;
 
 }
+
+interface MineralConstructor extends _Constructor<Mineral>, _ConstructorById<Mineral> {
+}
+
+declare const Mineral: MineralConstructor;

--- a/src/mineral.ts
+++ b/src/mineral.ts
@@ -8,13 +8,17 @@ interface Mineral extends RoomObject {
     readonly prototype: Mineral;
 
     /**
+     * Room cannot be undefined for a Mineral.
+     */
+    room: Room;
+    /**
      * The remaining amount of resources.
      */
     mineralAmount: number;
     /**
      * The resource type, one of the RESOURCE_* constants.
      */
-    mineralType: string;
+    mineralType: ResourceConst;
     /**
      * A unique object identificator. You can use Game.getObjectById method to retrieve an object instance by its id.
      */

--- a/src/nuke.ts
+++ b/src/nuke.ts
@@ -3,7 +3,11 @@
  */
 interface Nuke extends RoomObject {
     readonly prototype: Nuke;
-    
+
+    /**
+     * Room cannot be undefined for a Nuke.
+     */
+    room: Room;
     /**
      * A unique object identificator. You can use Game.getObjectById method to retrieve an object instance by its id.
      */

--- a/src/nuke.ts
+++ b/src/nuke.ts
@@ -2,6 +2,8 @@
  * A nuke landing position. This object cannot be removed or modified. You can find incoming nukes in the room using the FIND_NUKES constant.
  */
 interface Nuke extends RoomObject {
+    readonly prototype: Nuke;
+    
     /**
      * A unique object identificator. You can use Game.getObjectById method to retrieve an object instance by its id.
      */

--- a/src/nuke.ts
+++ b/src/nuke.ts
@@ -1,7 +1,7 @@
 /**
  * A nuke landing position. This object cannot be removed or modified. You can find incoming nukes in the room using the FIND_NUKES constant.
  */
-declare class Nuke extends RoomObject {
+interface Nuke extends RoomObject {
     /**
      * A unique object identificator. You can use Game.getObjectById method to retrieve an object instance by its id.
      */
@@ -15,3 +15,9 @@ declare class Nuke extends RoomObject {
      */
     timeToLand: number;
 }
+
+interface NukeConstructor {
+    new (id: string): Nuke;
+}
+
+declare const Nuke: NukeConstructor;

--- a/src/path-finder.ts
+++ b/src/path-finder.ts
@@ -16,15 +16,7 @@ interface PathFinder {
      * @param goal goal A RoomPosition or an object containing a RoomPosition and range
      * @param opts An object containing additional pathfinding flags.
      */
-    search(origin: RoomPosition, goal:  RoomPosition|{pos: RoomPosition, range: number}, opts?: PathFinderOpts): {path: RoomPosition[], ops:number};
-    /**
-     * Find an optimal path between origin and goal.
-     *
-     * @param origin The start position.
-     * @param goal an array of goals, the cheapest path found out of all the goals will be returned.
-     * @param opts An object containing additional pathfinding flags.
-     */
-    search(origin: RoomPosition, goal:  RoomPosition[]|{pos: RoomPosition, range: number}[], opts?: PathFinderOpts): {path: RoomPosition[], ops:number};
+    search(origin: RoomPosition, goal: PathFinderGoal | PathFinderGoal[], opts?: PathFinderOpts): PathFinderReturn;
     /**
      * Specify whether to use this new experimental pathfinder in game objects methods.
      * This method should be invoked every tick. It affects the following methods behavior:
@@ -33,6 +25,25 @@ interface PathFinder {
      * @param isEnabled Whether to activate the new pathfinder or deactivate.
      */
     use(isEnabled: boolean);
+}
+
+interface PathFinderReturn {
+    /**
+     * An array of RoomPosition objects.
+     */
+    path: RoomPosition[];
+    /**
+     * Total number of operations performed before this path was calculated.
+     */
+    ops: number;
+    /**
+     * The total cost of the path as derived from `plainCost`, `swampCost` and any given CostMatrix instances.
+     */
+    cost: number;
+    /**
+     * If the pathfinder fails to find a complete path, this will be true. Note that `path` will still be populated with a partial path which represents the closest path it could find given the search parameters.
+     */
+    incomplete: boolean;
 }
 
 /**

--- a/src/raw-memory.ts
+++ b/src/raw-memory.ts
@@ -1,4 +1,3 @@
-// Updated 2016-02-05
 /**
  * RawMemory object allows to implement your own memory stringifier instead of built-in serializer based on JSON.stringify.
  */

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -4,7 +4,11 @@
 
 interface Resource extends RoomObject {
     readonly prototype: Resource;
-    
+
+    /**
+     * Room cannot be undefined for a Resource.
+     */
+    room: Room;
     /**
      * The amount of resource units containing.
      */
@@ -16,7 +20,7 @@ interface Resource extends RoomObject {
     /**
      * One of the `RESOURCE_*` constants.
      */
-    resourceType: string;
+    resourceType: ResourceConst;
 }
 
 interface ResourceConstructor {

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -2,7 +2,7 @@
  * A dropped piece of resource. It will decay after a while if not picked up. Dropped resource pile decays for ceil(amount/1000) units per tick.
  */
 
-declare class Resource extends RoomObject {
+interface Resource extends RoomObject {
     /**
      * The amount of resource units containing.
      */
@@ -16,3 +16,9 @@ declare class Resource extends RoomObject {
      */
     resourceType: string;
 }
+
+interface ResourceConstructor {
+    new (id: string): Resource;
+}
+
+declare const Resource: ResourceConstructor;

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -3,6 +3,8 @@
  */
 
 interface Resource extends RoomObject {
+    readonly prototype: Resource;
+    
     /**
      * The amount of resource units containing.
      */

--- a/src/room-object.ts
+++ b/src/room-object.ts
@@ -14,7 +14,7 @@ interface RoomObject {
      * flag or a construction site and is placed in a room that is not visible
      * to you.
      */
-    room: Room;
+    room: Room | undefined;
 }
 
 interface RoomObjectConstructor extends _Constructor<RoomObject> {

--- a/src/room-object.ts
+++ b/src/room-object.ts
@@ -3,7 +3,7 @@
  * are derived from RoomObject.
  */
 
-declare class RoomObject {
+interface RoomObject {
     prototype: RoomObject;
     /**
      * An object representing the position of this object in the room.
@@ -16,3 +16,9 @@ declare class RoomObject {
      */
     room: Room;
 }
+
+interface RoomObjectConstructor {
+    //No accessible constructor
+}
+
+declare const RoomObject: RoomObjectConstructor;

--- a/src/room-object.ts
+++ b/src/room-object.ts
@@ -4,7 +4,7 @@
  */
 
 interface RoomObject {
-    prototype: RoomObject;
+    readonly prototype: RoomObject;
     /**
      * An object representing the position of this object in the room.
      */
@@ -17,8 +17,9 @@ interface RoomObject {
     room: Room;
 }
 
-interface RoomObjectConstructor {
-    //No accessible constructor
+interface RoomObjectConstructor extends _Constructor<RoomObject> {
+    new (x: number, y: number, roomName: string): RoomObject;
+    (x: number, y: number, roomName: string): RoomObject;
 }
 
 declare const RoomObject: RoomObjectConstructor;

--- a/src/room-position.ts
+++ b/src/room-position.ts
@@ -2,6 +2,8 @@
  * An object representing the specified position in the room. Every object in the room contains RoomPosition as the pos property. The position object of a custom location can be obtained using the Room.getPositionAt() method or using the constructor.
  */
 interface RoomPosition {
+    readonly prototype: RoomPosition;
+
     /**
      * The name of the room.
      */
@@ -138,7 +140,7 @@ interface RoomPosition {
     lookFor<T>(type: string): T[];
 }
 
-interface RoomPositionConstructor {
+interface RoomPositionConstructor extends _Constructor<RoomPosition> {
     /**
      * You can create new RoomPosition object using its constructor.
      * @param x X position in the room.
@@ -146,6 +148,7 @@ interface RoomPositionConstructor {
      * @param roomName The room name.
      */
     new (x: number, y: number, roomName: string): RoomPosition;
+    (x: number, y: number, roomName: string): RoomPosition;
 }
 
 declare const RoomPosition: RoomPositionConstructor;

--- a/src/room-position.ts
+++ b/src/room-position.ts
@@ -20,45 +20,45 @@ interface RoomPosition {
      * Create new ConstructionSite at the specified location.
      * @param structureType One of the following constants: STRUCTURE_EXTENSION, STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_SPAWN, STRUCTURE_WALL, STRUCTURE_LINK
      */
-    createConstructionSite(structureType: string): number;
+    createConstructionSite(structureType: StructureConst): ReturnConstOk | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrInvalidArgs | ReturnConstErrRCL;
     /**
      * Create new Flag at the specified location.
      * @param name The name of a new flag. It should be unique, i.e. the Game.flags object should not contain another flag with the same name (hash key). If not defined, a random name will be generated.
      * @param color The color of a new flag. Should be one of the COLOR_* constants
      * @param secondaryColor The secondary color of a new flag. Should be one of the COLOR_* constants. The default value is equal to color.
      */
-    createFlag(name?: string, color?: number, secondaryColor?: number): number;
+    createFlag(name?: string, color?: ColorConst, secondaryColor?: ColorConst): string | ReturnConstErrNameExists | ReturnConstErrInvalidArgs;
     /**
      * Find an object with the shortest path from the given position. Uses A* search algorithm and Dijkstra's algorithm.
      * @param type See Room.find
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      */
-    findClosestByPath<T>(type: number, opts?: FindPathOpts & { filter?: any | string, algorithm?: string }): T;
+    findClosestByPath<T>(type: FindConst, opts?: FindPathOpts & { filter?: any | string, algorithm?: PathfindingAlgorithm }): T | null;
     /**
      * Find an object with the shortest path from the given position. Uses A* search algorithm and Dijkstra's algorithm.
      * @param objects An array of room's objects or RoomPosition objects that the search should be executed against.
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      */
-    findClosestByPath<T>(objects: T[] | RoomPosition[], opts?: FindPathOpts & { filter?: any | string, algorithm?: string }): T;
+    findClosestByPath<T>(objects: T[] | RoomPosition[], opts?: FindPathOpts & { filter?: any | string, algorithm?: PathfindingAlgorithm }): T | null;
     /**
      * Find an object with the shortest linear distance from the given position.
      * @param type See Room.find.
      * @param opts
      */
-    findClosestByRange<T>(type: number, opts?: { filter: any | string }): T;
+    findClosestByRange<T>(type: FindConst, opts?: { filter: any | string }): T | null;
     /**
      * Find an object with the shortest linear distance from the given position.
      * @param objects An array of room's objects or RoomPosition objects that the search should be executed against.
      * @param opts An object containing one of the following options: filter
      */
-    findClosestByRange<T>(objects: T[] | RoomPosition[], opts?: { filter: any | string }): T;
+    findClosestByRange<T>(objects: T[] | RoomPosition[], opts?: { filter: any | string }): T | null;
     /**
      * Find all objects in the specified linear range.
      * @param type See Room.find.
      * @param range The range distance.
      * @param opts See Room.find.
      */
-    findInRange<T>(type: number, range: number, opts?: { filter?: any | string }): T[];
+    findInRange<T>(type: FindConst, range: number, opts?: { filter?: any | string }): T[];
     /**
      * Find all objects in the specified linear range.
      * @param objects An array of room's objects or RoomPosition objects that the search should be executed against.
@@ -84,12 +84,12 @@ interface RoomPosition {
      * @param x X position in the room.
      * @param y Y position in the room.
      */
-    getDirectionTo(x: number, y: number): number;
+    getDirectionTo(x: number, y: number): DirConst;
     /**
      * Get linear direction to the specified position.
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
      */
-    getDirectionTo(target: RoomPosition | { pos: RoomPosition }): number;
+    getDirectionTo(target: RoomPosition | { pos: RoomPosition }): DirConst;
     /**
      * Get linear range to the specified position.
      * @param x X position in the room.
@@ -103,10 +103,17 @@ interface RoomPosition {
     getRangeTo(target: RoomPosition | { pos: RoomPosition }): number;
     /**
      * Check whether this position is in the given range of another position.
-     * @param toPos The target position.
+     * @param x X position in the room.
+     * @param y Y position in the room.
      * @param range The range distance.
      */
-    inRangeTo(toPos: RoomPosition, range: number): boolean;
+    inRangeTo(x: number, y: number, range: number): boolean;
+    /**
+     * Check whether this position is in the given range of another position.
+     * @param target The target position.
+     * @param range The range distance.
+     */
+    inRangeTo(target: RoomPosition | { pos: RoomPosition }, range: number): boolean;
     /**
      * Check whether this position is the same as the specified position.
      * @param x X position in the room.
@@ -137,7 +144,7 @@ interface RoomPosition {
      * Get an object with the given type at the specified room position.
      * @param type One of the following string constants: constructionSite, creep, exit, flag, resource, source, structure, terrain
      */
-    lookFor<T>(type: string): T[];
+    lookFor<T>(type: LookConst): T[];
 }
 
 interface RoomPositionConstructor extends _Constructor<RoomPosition> {

--- a/src/room-position.ts
+++ b/src/room-position.ts
@@ -1,16 +1,7 @@
 /**
  * An object representing the specified position in the room. Every object in the room contains RoomPosition as the pos property. The position object of a custom location can be obtained using the Room.getPositionAt() method or using the constructor.
  */
-declare class RoomPosition {
-    /**
-     * You can create new RoomPosition object using its constructor.
-     * @param x X position in the room.
-     * @param y Y position in the room.
-     * @param roomName The room name.
-     */
-    //new(x: number, y: number, roomName: string): RoomPosition;
-    constructor (x: number, y: number, roomName: string);
-    
+interface RoomPosition {
     /**
      * The name of the room.
      */
@@ -40,39 +31,39 @@ declare class RoomPosition {
      * @param type See Room.find
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      */
-    findClosestByPath<T>(type: number, opts?: FindPathOpts & {filter?: any|string, algorithm?: string}): T;
+    findClosestByPath<T>(type: number, opts?: FindPathOpts & { filter?: any | string, algorithm?: string }): T;
     /**
      * Find an object with the shortest path from the given position. Uses A* search algorithm and Dijkstra's algorithm.
      * @param objects An array of room's objects or RoomPosition objects that the search should be executed against.
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      */
-    findClosestByPath<T>(objects: T[]|RoomPosition[], opts?: FindPathOpts & {filter?: any|string, algorithm?: string}): T;
+    findClosestByPath<T>(objects: T[] | RoomPosition[], opts?: FindPathOpts & { filter?: any | string, algorithm?: string }): T;
     /**
      * Find an object with the shortest linear distance from the given position.
      * @param type See Room.find.
      * @param opts
      */
-    findClosestByRange<T>(type: number, opts?: {filter: any|string }): T;
+    findClosestByRange<T>(type: number, opts?: { filter: any | string }): T;
     /**
      * Find an object with the shortest linear distance from the given position.
      * @param objects An array of room's objects or RoomPosition objects that the search should be executed against.
      * @param opts An object containing one of the following options: filter
      */
-    findClosestByRange<T>(objects: T[]|RoomPosition[], opts?: {filter: any|string }): T;
+    findClosestByRange<T>(objects: T[] | RoomPosition[], opts?: { filter: any | string }): T;
     /**
      * Find all objects in the specified linear range.
      * @param type See Room.find.
      * @param range The range distance.
      * @param opts See Room.find.
      */
-    findInRange<T>(type: number, range: number, opts?: {filter?: any|string}): T[];
+    findInRange<T>(type: number, range: number, opts?: { filter?: any | string }): T[];
     /**
      * Find all objects in the specified linear range.
      * @param objects An array of room's objects or RoomPosition objects that the search should be executed against.
      * @param range The range distance.
      * @param opts See Room.find.
      */
-    findInRange<T>(objects: T[]|RoomPosition[], range: number, opts?: {filter?: any|string}): T[];
+    findInRange<T>(objects: T[] | RoomPosition[], range: number, opts?: { filter?: any | string }): T[];
     /**
      * Find an optimal path to the specified position using A* search algorithm. This method is a shorthand for Room.findPath. If the target is in another room, then the corresponding exit will be used as a target.
      * @param x X position in the room.
@@ -85,7 +76,7 @@ declare class RoomPosition {
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
      * @param opts An object containing pathfinding options flags (see Room.findPath for more details).
      */
-    findPathTo(target: RoomPosition|{pos: RoomPosition}, opts?: FindPathOpts): PathStep[];
+    findPathTo(target: RoomPosition | { pos: RoomPosition }, opts?: FindPathOpts): PathStep[];
     /**
      * Get linear direction to the specified position.
      * @param x X position in the room.
@@ -96,7 +87,7 @@ declare class RoomPosition {
      * Get linear direction to the specified position.
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
      */
-    getDirectionTo(target: RoomPosition|{pos: RoomPosition}): number;
+    getDirectionTo(target: RoomPosition | { pos: RoomPosition }): number;
     /**
      * Get linear range to the specified position.
      * @param x X position in the room.
@@ -107,7 +98,7 @@ declare class RoomPosition {
      * Get linear range to the specified position.
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
      */
-    getRangeTo(target: RoomPosition|{pos: RoomPosition}): number;
+    getRangeTo(target: RoomPosition | { pos: RoomPosition }): number;
     /**
      * Check whether this position is in the given range of another position.
      * @param toPos The target position.
@@ -124,7 +115,7 @@ declare class RoomPosition {
      * Check whether this position is the same as the specified position.
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
      */
-    isEqualTo(target: RoomPosition|{pos: RoomPosition}): boolean;
+    isEqualTo(target: RoomPosition | { pos: RoomPosition }): boolean;
     /**
      * Check whether this position is on the adjacent square to the specified position. The same as inRangeTo(target, 1).
      * @param x X position in the room.
@@ -135,7 +126,7 @@ declare class RoomPosition {
      * Check whether this position is on the adjacent square to the specified position. The same as inRangeTo(target, 1).
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
      */
-    isNearTo(target: RoomPosition|{pos: RoomPosition}): boolean;
+    isNearTo(target: RoomPosition | { pos: RoomPosition }): boolean;
     /**
      * Get the list of objects at the specified room position.
      */
@@ -146,3 +137,15 @@ declare class RoomPosition {
      */
     lookFor<T>(type: string): T[];
 }
+
+interface RoomPositionConstructor {
+    /**
+     * You can create new RoomPosition object using its constructor.
+     * @param x X position in the room.
+     * @param y Y position in the room.
+     * @param roomName The room name.
+     */
+    new (x: number, y: number, roomName: string): RoomPosition;
+}
+
+declare const RoomPosition: RoomPositionConstructor;

--- a/src/room.ts
+++ b/src/room.ts
@@ -2,8 +2,7 @@
 /**
  * An object representing the room in which your units and structures are in. It can be used to look around, find paths, etc. Every object in the room contains its linked Room instance in the room property.
  */
-declare class Room {
-
+interface Room {
     /**
      * The Controller structure of this room, if present, otherwise undefined.
      */
@@ -48,14 +47,14 @@ declare class Room {
      * @param structureType One of the following constants: STRUCTURE_EXTENSION, STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_SPAWN, STRUCTURE_WALL, STRUCTURE_LINK
      * @returns Result Code: OK, ERR_INVALID_TARGET, ERR_INVALID_ARGS, ERR_RCL_NOT_ENOUGH
      */
-    createConstructionSite(x: number, y: number, structureType: string) : number;
+    createConstructionSite(x: number, y: number, structureType: string): number;
     /**
      * Create new ConstructionSite at the specified location.
      * @param pos Can be a RoomPosition object or any object containing RoomPosition.
      * @param structureType One of the following constants: STRUCTURE_EXTENSION, STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_SPAWN, STRUCTURE_WALL, STRUCTURE_LINK
      * @returns Result Code: OK, ERR_INVALID_TARGET, ERR_INVALID_ARGS, ERR_RCL_NOT_ENOUGH
      */
-    createConstructionSite(pos: RoomPosition|{pos: RoomPosition}, structureType: string): number;
+    createConstructionSite(pos: RoomPosition | { pos: RoomPosition }, structureType: string): number;
     /**
      * Create new Flag at the specified location.
      * @param x The X position.
@@ -64,7 +63,7 @@ declare class Room {
      * @param color The color of a new flag. Should be one of the COLOR_* constants. The default value is COLOR_WHITE.
      * @param secondaryColor The secondary color of a new flag. Should be one of the COLOR_* constants. The default value is equal to color.
      */
-    createFlag(x: number, y:number, name?: string, color?: number, secondaryColor?: number): number;
+    createFlag(x: number, y: number, name?: string, color?: number, secondaryColor?: number): number;
     /**
      * Create new Flag at the specified location.
      * @param pos Can be a RoomPosition object or any object containing RoomPosition.
@@ -72,21 +71,21 @@ declare class Room {
      * @param color The color of a new flag. Should be one of the COLOR_* constants. The default value is COLOR_WHITE.
      * @param secondaryColor The secondary color of a new flag. Should be one of the COLOR_* constants. The default value is equal to color.
      */
-    createFlag(pos: RoomPosition|{pos: RoomPosition}, name?: string, color?: number, secondaryColor?: number): number;
+    createFlag(pos: RoomPosition | { pos: RoomPosition }, name?: string, color?: number, secondaryColor?: number): number;
     /**
      * Find all objects of the specified type in the room.
      * @param type One of the following constants:FIND_CREEPS, FIND_MY_CREEPS, FIND_HOSTILE_CREEPS, FIND_MY_SPAWNS, FIND_HOSTILE_SPAWNS, FIND_SOURCES, FIND_SOURCES_ACTIVE, FIND_DROPPED_RESOURCES, FIND_DROPPED_ENERGY, FIND_STRUCTURES, FIND_MY_STRUCTURES, FIND_HOSTILE_STRUCTURES, FIND_FLAGS, FIND_CONSTRUCTION_SITES, FIND_EXIT_TOP, FIND_EXIT_RIGHT, FIND_EXIT_BOTTOM, FIND_EXIT_LEFT, FIND_EXIT
      * @param opts An object with additional options
      * @returns An array with the objects found.
      */
-    find<T>(type: number, opts?: {filter: Object | Function | string}): T[];
+    find<T>(type: number, opts?: { filter: Object | Function | string }): T[];
     /**
      * Find the exit direction en route to another room.
      * @param room Another room name or room object.
      * @returns The room direction constant, one of the following: FIND_EXIT_TOP, FIND_EXIT_RIGHT, FIND_EXIT_BOTTOM, FIND_EXIT_LEFT
      * Or one of the following error codes: ERR_NO_PATH, ERR_INVALID_ARGS
      */
-    findExitTo(room: string|Room): number;
+    findExitTo(room: string | Room): number;
     /**
      * Find an optimal path inside the room between fromPos and toPos using A* search algorithm.
      * @param fromPos The start position.
@@ -94,7 +93,7 @@ declare class Room {
      * @param opts (optional) An object containing additonal pathfinding flags
      * @returns An array with path steps
      */
-    findPath(fromPos: RoomPosition, toPos: RoomPosition, opts?: FindPathOpts) : PathStep[];
+    findPath(fromPos: RoomPosition, toPos: RoomPosition, opts?: FindPathOpts): PathStep[];
     /**
      * Creates a RoomPosition object at the specified location.
      * @param x The X position.
@@ -114,7 +113,7 @@ declare class Room {
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
      * @returns An array with objects at the specified position
      */
-    lookAt(target: RoomPosition|{pos: RoomPosition}) : LookAtResult[];
+    lookAt(target: RoomPosition | { pos: RoomPosition }): LookAtResult[];
     /**
      * Get the list of objects at the specified room area. This method is more CPU efficient in comparison to multiple lookAt calls.
      * @param top The top Y boundary of the area.
@@ -131,14 +130,14 @@ declare class Room {
      * @param y The Y position.
      * @returns An array of objects of the given type at the specified position if found.
      */
-    lookForAt<T>(type: string, x: number, y: number) : T[];
+    lookForAt<T>(type: string, x: number, y: number): T[];
     /**
      * Get an object with the given type at the specified room position.
      * @param type One of the following string constants: constructionSite, creep, energy, exit, flag, source, structure, terrain
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
      * @returns An array of objects of the given type at the specified position if found.
      */
-    lookForAt<T>(type: string, target: RoomPosition|{pos: RoomPosition}): T[];
+    lookForAt<T>(type: string, target: RoomPosition | { pos: RoomPosition }): T[];
     /**
      * Get the list of objects with the given type at the specified room area. This method is more CPU efficient in comparison to multiple lookForAt calls.
      * @param type One of the following string constants: constructionSite, creep, energy, exit, flag, source, structure, terrain
@@ -155,12 +154,18 @@ declare class Room {
      * @param path A path array retrieved from Room.findPath.
      * @returns A serialized string form of the given path.
      */
-    static serializePath(path: PathStep[]): string;
 
     /**
      * Deserialize a short string path representation into an array form.
      * @param path A serialized path string.
      * @returns A path array.
      */
-    static deserializePath(path: string): PathStep[];
 }
+
+interface RoomConstructor {
+    new (id: string): Room;
+    serializePath(path: PathStep[]): string;
+    deserializePath(path: string): PathStep[];
+}
+
+declare const Room: RoomConstructor;

--- a/src/room.ts
+++ b/src/room.ts
@@ -3,7 +3,7 @@
  */
 interface Room {
     readonly prototype: Room;
-    
+
     /**
      * The Controller structure of this room, if present, otherwise undefined.
      */
@@ -24,7 +24,7 @@ interface Room {
      * One of the following constants:
      * MODE_SIMULATION, MODE_SURVIVAL, MODE_WORLD, MODE_ARENA
      */
-    mode: string;
+    mode: ModeConst;
     /**
      * The name of the room.
      */
@@ -48,14 +48,14 @@ interface Room {
      * @param structureType One of the following constants: STRUCTURE_EXTENSION, STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_SPAWN, STRUCTURE_WALL, STRUCTURE_LINK
      * @returns Result Code: OK, ERR_INVALID_TARGET, ERR_INVALID_ARGS, ERR_RCL_NOT_ENOUGH
      */
-    createConstructionSite(x: number, y: number, structureType: string): number;
+    createConstructionSite(x: number, y: number, structureType: StructureConst): ReturnConstOk | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrInvalidArgs | ReturnConstErrRCL;
     /**
      * Create new ConstructionSite at the specified location.
      * @param pos Can be a RoomPosition object or any object containing RoomPosition.
      * @param structureType One of the following constants: STRUCTURE_EXTENSION, STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_SPAWN, STRUCTURE_WALL, STRUCTURE_LINK
      * @returns Result Code: OK, ERR_INVALID_TARGET, ERR_INVALID_ARGS, ERR_RCL_NOT_ENOUGH
      */
-    createConstructionSite(pos: RoomPosition | { pos: RoomPosition }, structureType: string): number;
+    createConstructionSite(pos: RoomPosition | { pos: RoomPosition }, structureType: StructureConst): ReturnConstOk | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrInvalidArgs | ReturnConstErrRCL;
     /**
      * Create new Flag at the specified location.
      * @param x The X position.
@@ -64,7 +64,7 @@ interface Room {
      * @param color The color of a new flag. Should be one of the COLOR_* constants. The default value is COLOR_WHITE.
      * @param secondaryColor The secondary color of a new flag. Should be one of the COLOR_* constants. The default value is equal to color.
      */
-    createFlag(x: number, y: number, name?: string, color?: number, secondaryColor?: number): number;
+    createFlag(x: number, y: number, name?: string, color?: ColorConst, secondaryColor?: ColorConst): string | ReturnConstErrNameExists | ReturnConstErrInvalidArgs;
     /**
      * Create new Flag at the specified location.
      * @param pos Can be a RoomPosition object or any object containing RoomPosition.
@@ -72,21 +72,21 @@ interface Room {
      * @param color The color of a new flag. Should be one of the COLOR_* constants. The default value is COLOR_WHITE.
      * @param secondaryColor The secondary color of a new flag. Should be one of the COLOR_* constants. The default value is equal to color.
      */
-    createFlag(pos: RoomPosition | { pos: RoomPosition }, name?: string, color?: number, secondaryColor?: number): number;
+    createFlag(pos: RoomPosition | { pos: RoomPosition }, name?: string, color?: ColorConst, secondaryColor?: ColorConst): string | ReturnConstErrNameExists | ReturnConstErrInvalidArgs;
     /**
      * Find all objects of the specified type in the room.
      * @param type One of the following constants:FIND_CREEPS, FIND_MY_CREEPS, FIND_HOSTILE_CREEPS, FIND_MY_SPAWNS, FIND_HOSTILE_SPAWNS, FIND_SOURCES, FIND_SOURCES_ACTIVE, FIND_DROPPED_RESOURCES, FIND_DROPPED_ENERGY, FIND_STRUCTURES, FIND_MY_STRUCTURES, FIND_HOSTILE_STRUCTURES, FIND_FLAGS, FIND_CONSTRUCTION_SITES, FIND_EXIT_TOP, FIND_EXIT_RIGHT, FIND_EXIT_BOTTOM, FIND_EXIT_LEFT, FIND_EXIT
      * @param opts An object with additional options
      * @returns An array with the objects found.
      */
-    find<T>(type: number, opts?: { filter: Object | Function | string }): T[];
+    find<T>(type: FindConst, opts?: { filter: Object | Function | string }): T[];
     /**
      * Find the exit direction en route to another room.
      * @param room Another room name or room object.
      * @returns The room direction constant, one of the following: FIND_EXIT_TOP, FIND_EXIT_RIGHT, FIND_EXIT_BOTTOM, FIND_EXIT_LEFT
      * Or one of the following error codes: ERR_NO_PATH, ERR_INVALID_ARGS
      */
-    findExitTo(room: string | Room): number;
+    findExitTo(room: string | Room): FindConstExit | ReturnConstErrNoPath | ReturnConstErrInvalidArgs;
     /**
      * Find an optimal path inside the room between fromPos and toPos using A* search algorithm.
      * @param fromPos The start position.
@@ -131,14 +131,14 @@ interface Room {
      * @param y The Y position.
      * @returns An array of objects of the given type at the specified position if found.
      */
-    lookForAt<T>(type: string, x: number, y: number): T[];
+    lookForAt<T>(type: LookConst, x: number, y: number): T[];
     /**
      * Get an object with the given type at the specified room position.
      * @param type One of the following string constants: constructionSite, creep, energy, exit, flag, source, structure, terrain
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
      * @returns An array of objects of the given type at the specified position if found.
      */
-    lookForAt<T>(type: string, target: RoomPosition | { pos: RoomPosition }): T[];
+    lookForAt<T>(type: LookConst, target: RoomPosition | { pos: RoomPosition }): T[];
     /**
      * Get the list of objects with the given type at the specified room area. This method is more CPU efficient in comparison to multiple lookForAt calls.
      * @param type One of the following string constants: constructionSite, creep, energy, exit, flag, source, structure, terrain
@@ -148,24 +148,43 @@ interface Room {
      * @param right The right X boundary of the area.
      * @returns An object with all the objects of the given type in the specified area
      */
-    lookForAtArea(type: string, top: number, left: number, bottom: number, right: number, asArray?: boolean): LookAtResultMatrix | LookAtResultWithPos[];
+    lookForAtArea(type: LookConst, top: number, left: number, bottom: number, right: number, asArray: true): LookAtResultWithPos[];
+    /**
+     * Get the list of objects with the given type at the specified room area. This method is more CPU efficient in comparison to multiple lookForAt calls.
+     * @param type One of the following string constants: constructionSite, creep, energy, exit, flag, source, structure, terrain
+     * @param top The top Y boundary of the area.
+     * @param left The left X boundary of the area.
+     * @param bottom The bottom Y boundary of the area.
+     * @param right The right X boundary of the area.
+     * @returns An object with all the objects of the given type in the specified area
+     */
+    lookForAtArea(type: LookConst, top: number, left: number, bottom: number, right: number, asArray?: false): LookAtResultMatrix;
+    /**
+     * Get the list of objects with the given type at the specified room area. This method is more CPU efficient in comparison to multiple lookForAt calls.
+     * @param type One of the following string constants: constructionSite, creep, energy, exit, flag, source, structure, terrain
+     * @param top The top Y boundary of the area.
+     * @param left The left X boundary of the area.
+     * @param bottom The bottom Y boundary of the area.
+     * @param right The right X boundary of the area.
+     * @returns An object with all the objects of the given type in the specified area
+     */
+    lookForAtArea(type: LookConst, top: number, left: number, bottom: number, right: number, asArray?: boolean): LookAtResultMatrix | LookAtResultWithPos[];
+}
+
+interface RoomConstructor {
+    new (id: string): Room;
 
     /**
      * Serialize a path array into a short string representation, which is suitable to store in memory.
      * @param path A path array retrieved from Room.findPath.
      * @returns A serialized string form of the given path.
      */
-
+    serializePath(path: PathStep[]): string;
     /**
      * Deserialize a short string path representation into an array form.
      * @param path A serialized path string.
      * @returns A path array.
      */
-}
-
-interface RoomConstructor {
-    new (id: string): Room;
-    serializePath(path: PathStep[]): string;
     deserializePath(path: string): PathStep[];
 }
 

--- a/src/room.ts
+++ b/src/room.ts
@@ -1,8 +1,9 @@
-// Updated 2016-02-05
 /**
  * An object representing the room in which your units and structures are in. It can be used to look around, find paths, etc. Every object in the room contains its linked Room instance in the room property.
  */
 interface Room {
+    readonly prototype: Room;
+    
     /**
      * The Controller structure of this room, if present, otherwise undefined.
      */

--- a/src/source.ts
+++ b/src/source.ts
@@ -6,7 +6,7 @@ interface Source extends RoomObject {
     /**
      * The prototype is stored in the Source.prototype global object. You can use it to extend game objects behaviour globally:
      */
-    prototype: Source;
+    readonly prototype: Source;
     /**
      * The remaining amount of energy.
      */
@@ -25,8 +25,7 @@ interface Source extends RoomObject {
     ticksToRegeneration: number;
 }
 
-interface SourceConstructor {
-    new (id: string): Source;
+interface SourceConstructor extends _Constructor<Source>, _ConstructorById<Source> {
 }
 
 declare const Source: SourceConstructor;

--- a/src/source.ts
+++ b/src/source.ts
@@ -7,6 +7,11 @@ interface Source extends RoomObject {
      * The prototype is stored in the Source.prototype global object. You can use it to extend game objects behaviour globally:
      */
     readonly prototype: Source;
+
+    /**
+     * Room cannot be undefined for a Source.
+     */
+    room: Room;
     /**
      * The remaining amount of energy.
      */

--- a/src/source.ts
+++ b/src/source.ts
@@ -2,7 +2,7 @@
 /**
  * An energy source object. Can be harvested by creeps with a WORK body part.
  */
-declare class Source extends RoomObject{
+interface Source extends RoomObject {
     /**
      * The prototype is stored in the Source.prototype global object. You can use it to extend game objects behaviour globally:
      */
@@ -24,3 +24,9 @@ declare class Source extends RoomObject{
      */
     ticksToRegeneration: number;
 }
+
+interface SourceConstructor {
+    new (id: string): Source;
+}
+
+declare const Source: SourceConstructor;

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -1,10 +1,9 @@
-// Updated 2016-02-05
 /**
  * Spawns are your colony centers. You can transfer energy into it and create new creeps using createCreep() method.
  */
 interface StructureSpawn extends OwnedStructure {
     readonly prototype: StructureSpawn;
-    
+
     /**
      * The amount of energy containing in the spawn.
      */
@@ -14,59 +13,31 @@ interface StructureSpawn extends OwnedStructure {
      */
     energyCapacity: number;
     /**
-     * The current amount of hit points of the spawn.
-     */
-    hits: number;
-    /**
-     * The maximum amount of hit points of the spawn.
-     */
-    hitsMax: number;
-    /**
-     * A unique object identificator. You can use Game.getObjectById method to retrieve an object instance by its id.
-     */
-    id: string;
-    /**
      * A shorthand to Memory.spawns[spawn.name]. You can use it for quick access the spawn’s specific memory data object.
      */
     memory: any;
-    /**
-     * Whether it is your spawn or foe.
-     */
-    my: boolean;
     /**
      * Spawn’s name. You choose the name upon creating a new spawn, and it cannot be changed later. This name is a hash key to access the spawn via the Game.spawns object.
      */
     name: string;
     /**
-     * An object with the spawn’s owner info containing the following properties: username
-     */
-    owner: Owner;
-    /**
-     * An object representing the position of this spawn in a room.
-     */
-    pos: RoomPosition;
-    /**
-     * The link to the Room object of this spawn.
-     */
-    room: Room;
-    /**
      * Always equal to ‘spawn’.
      */
-    structureType: string;
+    structureType: StructureConstSpawn;
     /**
      * If the spawn is in process of spawning a new creep, this object will contain the new creep’s information, or null otherwise.
      * @param name The name of a new creep.
      * @param needTime Time needed in total to complete the spawning.
      * @param remainingTime Remaining time to go.
      */
-    spawning: { name: string, needTime: number, remainingTime: number };
+    spawning: { name: string, needTime: number, remainingTime: number } | null;
 
     /**
      * Check if a creep can be created.
      * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of these constants: WORK, MOVE, CARRY, ATTACK, RANGED_ATTACK, HEAL, TOUGH, CLAIM
      * @param name The name of a new creep. It should be unique creep name, i.e. the Game.creeps object should not contain another creep with the same name (hash key). If not defined, a random name will be generated.
      */
-    canCreateCreep(body: string[], name?: string): number;
+    canCreateCreep(body: BodypartConst[], name?: string): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrNameExists | ReturnConstErrBusy | ReturnConstErrNotEnough | ReturnConstErrInvalidArgs | ReturnConstErrRCL;
     /**
      * Start the creep spawning process.
      * The name of a new creep or one of these error codes
@@ -80,36 +51,25 @@ interface StructureSpawn extends OwnedStructure {
      * @param name The name of a new creep. It should be unique creep name, i.e. the Game.creeps object should not contain another creep with the same name (hash key). If not defined, a random name will be generated.
      * @param memory The memory of a new creep. If provided, it will be immediately stored into Memory.creeps[name].
      */
-    createCreep(body: string[], name?: string, memory?: any): number | string;
-    /**
-     * Destroy this spawn immediately.
-     */
-    destroy(): number;
-    /**
-     * Check whether this structure can be used. If the room controller level is not enough, then this method will return false, and the structure will be highlighted with red in the game.
-     */
-    isActive(): boolean;
-    /**
-     * Toggle auto notification when the spawn is under attack. The notification will be sent to your account email. Turned on by default.
-     * @param enabled Whether to enable notification or disable.
-     */
-    notifyWhenAttacked(enabled: boolean): number;
-    /**
-     * Increase the remaining time to live of the target creep. The target should be at adjacent square. The spawn should not be busy with the spawning process. Each execution increases the creep's timer by amount of ticks according to this formula: floor(500/body_size). Energy required for each execution is determined using this formula: ceil(creep_cost/3/body_size).
-     * @param target The target creep object.
-     */
-    renewCreep(target: Creep): number;
+    createCreep(body: BodypartConst[], name?: string, memory?: any): string | ReturnConstErrNotOwner | ReturnConstErrNameExists | ReturnConstErrBusy | ReturnConstErrNotEnough | ReturnConstErrInvalidArgs | ReturnConstErrRCL;
     /**
      * Kill the creep and drop up to 100% of resources spent on its spawning and boosting depending on remaining life time. The target should be at adjacent square.
      * @param target The target creep object.
      */
-    recycleCreep(target: Creep): number;
+    recycleCreep(target: Creep): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrInvalidTarget | ReturnConstErrNotInRange;
     /**
+     * Increase the remaining time to live of the target creep. The target should be at adjacent square. The spawn should not be busy with the spawning process. Each execution increases the creep's timer by amount of ticks according to this formula: floor(500/body_size). Energy required for each execution is determined using this formula: ceil(creep_cost/3/body_size).
+     * @param target The target creep object.
+     */
+    renewCreep(target: Creep): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrBusy | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrNotInRange;
+    /**
+     * DEPRECATED: Please use Creep.withdraw instead.
      * Transfer the energy from the spawn to a creep.
      * @param target The creep object which energy should be transferred to.
      * @param amount The amount of energy to be transferred. If omitted, all the remaining amount of energy will be used.
+     * @deprecated
      */
-    transferEnergy(target: Creep, amount?: number): number;
+    transferEnergy(target: Creep, amount?: number): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrNotInRange;
 }
 
 

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -3,6 +3,8 @@
  * Spawns are your colony centers. You can transfer energy into it and create new creeps using createCreep() method.
  */
 interface StructureSpawn extends OwnedStructure {
+    readonly prototype: StructureSpawn;
+    
     /**
      * The amount of energy containing in the spawn.
      */
@@ -110,13 +112,14 @@ interface StructureSpawn extends OwnedStructure {
     transferEnergy(target: Creep, amount?: number): number;
 }
 
-interface Spawn extends StructureSpawn {
-    //Legacy Alias
-}
 
-interface StructureSpawnConstructor {
-    new (id: string): StructureSpawn;
+interface StructureSpawnConstructor extends _Constructor<StructureSpawn>, _ConstructorById<StructureSpawn> {
 }
 
 declare const StructureSpawn: StructureSpawnConstructor;
+
+interface Spawn extends StructureSpawn {
+    //Legacy Alias
+    readonly prototype: StructureSpawn;
+}
 declare const Spawn: StructureSpawnConstructor;//Legacy Alias

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -2,7 +2,7 @@
 /**
  * Spawns are your colony centers. You can transfer energy into it and create new creeps using createCreep() method.
  */
-declare class Spawn extends OwnedStructure{
+interface StructureSpawn extends OwnedStructure {
     /**
      * The amount of energy containing in the spawn.
      */
@@ -57,7 +57,7 @@ declare class Spawn extends OwnedStructure{
      * @param needTime Time needed in total to complete the spawning.
      * @param remainingTime Remaining time to go.
      */
-    spawning: {name: string, needTime: number, remainingTime: number};
+    spawning: { name: string, needTime: number, remainingTime: number };
 
     /**
      * Check if a creep can be created.
@@ -110,5 +110,13 @@ declare class Spawn extends OwnedStructure{
     transferEnergy(target: Creep, amount?: number): number;
 }
 
-declare class StructureSpawn extends Spawn {
+interface Spawn extends StructureSpawn {
+    //Legacy Alias
 }
+
+interface StructureSpawnConstructor {
+    new (id: string): StructureSpawn;
+}
+
+declare const StructureSpawn: StructureSpawnConstructor;
+declare const Spawn: StructureSpawnConstructor;//Legacy Alias

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -117,9 +117,3 @@ interface StructureSpawnConstructor extends _Constructor<StructureSpawn>, _Const
 }
 
 declare const StructureSpawn: StructureSpawnConstructor;
-
-interface Spawn extends StructureSpawn {
-    //Legacy Alias
-    readonly prototype: StructureSpawn;
-}
-declare const Spawn: StructureSpawnConstructor;//Legacy Alias

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -2,7 +2,7 @@
  * Parent object for structure classes
  */
 
-declare class Structure extends RoomObject {
+interface Structure extends RoomObject {
     /**
      * The current amount of hit points of the structure.
      */
@@ -34,11 +34,17 @@ declare class Structure extends RoomObject {
     notifyWhenAttacked(enabled: boolean): number;
 }
 
+interface StructureConstructor {
+    new (id: string): Structure;
+}
+
+declare const Structure: StructureConstructor;
+
 /**
  * The base prototype for a structure that has an owner. Such structures can be
  * found using `FIND_MY_STRUCTURES` and `FIND_HOSTILE_STRUCTURES` constants.
  */
-declare class OwnedStructure extends Structure {
+interface OwnedStructure extends Structure {
     /**
      * Whether this is your own structure. Walls and roads don't have this property as they are considered neutral structures.
      */
@@ -50,12 +56,18 @@ declare class OwnedStructure extends Structure {
 
 }
 
+interface OwnedStructureConstructor {
+    new (id: string): OwnedStructure;
+}
+
+declare const OwnedStructure: OwnedStructureConstructor;
+
 /**
  * Claim this structure to take control over the room. The controller structure
  * cannot be damaged or destroyed. It can be addressed by `Room.controller`
  * property.
  */
-declare class StructureController extends OwnedStructure {
+interface StructureController extends OwnedStructure {
     /**
      * Current controller level, from 0 to 8.
      */
@@ -86,12 +98,18 @@ declare class StructureController extends OwnedStructure {
     unclaim(): number;
 }
 
+interface StructureControllerConstructor {
+    new (id: string): StructureController;
+}
+
+declare const StructureController: StructureControllerConstructor;
+
 /**
  * Contains energy which can be spent on spawning bigger creeps. Extensions can
  * be placed anywhere in the room, any spawns will be able to use them regardless
  * of distance.
  */
-declare class StructureExtension extends OwnedStructure {
+interface StructureExtension extends OwnedStructure {
     /**
      * The amount of energy containing in the extension.
      */
@@ -108,10 +126,16 @@ declare class StructureExtension extends OwnedStructure {
     transferEnergy(target: Creep, amount?: number): number;
 }
 
+interface StructureExtensionConstructor {
+    new (id: string): StructureExtension;
+}
+
+declare const StructureExtension: StructureExtensionConstructor;
+
 /**
  * Remotely transfers energy to another Link in the same room.
  */
-declare class StructureLink extends OwnedStructure {
+interface StructureLink extends OwnedStructure {
     /**
      * The amount of game ticks the link has to wait until the next transfer is possible.
      */
@@ -132,21 +156,33 @@ declare class StructureLink extends OwnedStructure {
     transferEnergy(target: Creep | StructureLink, amount?: number): number;
 }
 
+interface StructureLinkConstructor {
+    new (id: string): StructureLink;
+}
+
+declare const StructureLink: StructureLinkConstructor;
+
 /**
  * Non-player structure. Spawns NPC Source Keepers that guards energy sources
  * and minerals in some rooms. This structure cannot be destroyed.
  */
-declare class StructureKeeperLair extends OwnedStructure {
+interface StructureKeeperLair extends OwnedStructure {
     /**
      * Time to spawning of the next Source Keeper.
      */
     ticksToSpawn: number | undefined;
 }
 
+interface StructureKeeperLairConstructor {
+    new (id: string): StructureKeeperLair;
+}
+
+declare const StructureKeeperLair: StructureKeeperLairConstructor;
+
 /**
  * Provides visibility into a distant room from your script.
  */
-declare class StructureObserver extends OwnedStructure {
+interface StructureObserver extends OwnedStructure {
     /**
      * Provide visibility into a distant room from your script. The target room object will be available on the next tick. The maximum range is 5 rooms.
      * @param roomName
@@ -154,10 +190,16 @@ declare class StructureObserver extends OwnedStructure {
     observeRoom(roomName: string): number;
 }
 
+interface StructureObserverConstructor {
+    new (id: string): StructureObserver;
+}
+
+declare const StructureObserver: StructureObserverConstructor;
+
 /**
  *
  */
-declare class StructurePowerBank extends OwnedStructure {
+interface StructurePowerBank extends OwnedStructure {
     /**
      * The amount of power containing.
      */
@@ -168,11 +210,17 @@ declare class StructurePowerBank extends OwnedStructure {
     ticksToDecay: number;
 }
 
+interface StructurePowerBankConstructor {
+    new (id: string): StructurePowerBank;
+}
+
+declare const StructurePowerBank: StructurePowerBankConstructor;
+
 /**
  * Non-player structure. Contains power resource which can be obtained by
  * destroying the structure. Hits the attacker creep back on each attack.
  */
-declare class StructurePowerSpawn extends OwnedStructure {
+interface StructurePowerSpawn extends OwnedStructure {
     /**
      * The amount of energy containing in this structure.
      */
@@ -208,11 +256,17 @@ declare class StructurePowerSpawn extends OwnedStructure {
 
 }
 
+interface StructurePowerSpawnConstructor {
+    new (id: string): StructurePowerSpawn;
+}
+
+declare const StructurePowerSpawn: StructurePowerSpawnConstructor;
+
 /**
  * Blocks movement of hostile creeps, and defends your creeps and structures on
  * the same tile. Can be used as a controllable gate.
  */
-declare class StructureRampart extends OwnedStructure {
+interface StructureRampart extends OwnedStructure {
     /**
      * The amount of game ticks when this rampart will lose some hit points.
      */
@@ -230,22 +284,34 @@ declare class StructureRampart extends OwnedStructure {
     setPublic(isPublic: boolean);
 }
 
+interface StructureRampartConstructor {
+    new (id: string): StructureRampart;
+}
+
+declare const StructureRampart: StructureRampartConstructor;
+
 /**
  * Decreases movement cost to 1. Using roads allows creating creeps with less
  * `MOVE` body parts.
  */
-declare class StructureRoad extends Structure {
+interface StructureRoad extends Structure {
     /**
      * The amount of game ticks when this road will lose some hit points.
      */
     ticksToDecay: number;
 }
 
+interface StructureRoadConstructor {
+    new (id: string): StructureRoad;
+}
+
+declare const StructureRoad: StructureRoadConstructor;
+
 /**
  * A structure that can store huge amount of resource units. Only one structure
  * per room is allowed that can be addressed by `Room.storage` property.
  */
-declare class StructureStorage extends OwnedStructure {
+interface StructureStorage extends OwnedStructure {
 
     /**
      * An object with the storage contents.
@@ -272,12 +338,18 @@ declare class StructureStorage extends OwnedStructure {
     transferEnergy(target: Creep, amount?: number): number;
 }
 
+interface StructureStorageConstructor {
+    new (id: string): StructureStorage;
+}
+
+declare const StructureStorage: StructureStorageConstructor;
+
 /**
  * Remotely attacks or heals creeps, or repairs structures. Can be targeted to
  * any object in the room. However, its effectiveness highly depends on the
  * distance. Each action consumes energy.
  */
-declare class StructureTower extends OwnedStructure {
+interface StructureTower extends OwnedStructure {
     /**
      * The amount of energy containing in this structure.
      */
@@ -310,27 +382,44 @@ declare class StructureTower extends OwnedStructure {
     transferEnergy(target: Creep, amount?: number): number;
 }
 
+interface StructureTowerConstructor {
+    new (id: string): StructureTower;
+}
+
+declare const StructureTower: StructureTowerConstructor;
+
 /**
  * Blocks movement of all creeps.
  */
-declare class StructureWall extends Structure {
+interface StructureWall extends Structure {
     /**
      * The amount of game ticks when the wall will disappear (only for automatically placed border walls at the start of the game).
      */
     ticksToLive: number;
 }
 
+interface StructureWallConstructor {
+    new (id: string): StructureWall;
+}
+
+declare const StructureWall: StructureWallConstructor;
+
 /**
  * Allows to harvest mineral deposits.
  */
-declare class StructureExtractor extends OwnedStructure {
-
+interface StructureExtractor extends OwnedStructure {
 }
+
+interface StructureExtractorConstructor {
+    new (id: string): StructureExtractor;
+}
+
+declare const StructureExtractor: StructureExtractorConstructor;
 
 /**
  * Produces mineral compounds from base minerals and boosts creeps.
  */
-declare class StructureLab extends OwnedStructure {
+interface StructureLab extends OwnedStructure {
     /**
      * The amount of game ticks the lab has to wait until the next reaction is possible.
      */
@@ -376,10 +465,16 @@ declare class StructureLab extends OwnedStructure {
     transfer(target: Creep, resourceType: string, amount?: number): number;
 }
 
+interface StructureLabConstructor {
+    new (id: string): StructureLab;
+}
+
+declare const StructureLab: StructureLabConstructor;
+
 /**
  * Sends any resources to a Terminal in another room.
  */
-declare class StructureTerminal extends OwnedStructure {
+interface StructureTerminal extends OwnedStructure {
     /**
      * An object with the storage contents. Each object key is one of the RESOURCE_* constants, values are resources amounts.
      */
@@ -405,10 +500,16 @@ declare class StructureTerminal extends OwnedStructure {
     transfer(target: Creep, resourceType: String, amount?: number): number;
 }
 
+interface StructureTerminalConstructor {
+    new (id: string): StructureTerminal;
+}
+
+declare const StructureTerminal: StructureTerminalConstructor;
+
 /**
  * Contains up to 2,000 resource units. Can be constructed in neutral rooms. Decays for 5,000 hits per 100 ticks.
  */
-declare class StructureContainer extends Structure {
+interface StructureContainer extends Structure {
     /**
      * An object with the structure contents. Each object key is one of the RESOURCE_* constants, values are resources
      * amounts. Use _.sum(structure.store) to get the total amount of contents
@@ -427,6 +528,12 @@ declare class StructureContainer extends Structure {
     transfer(target: Creep, resourceType: string, amount?: number): number;
 }
 
+interface StructureContainerConstructor {
+    new (id: string): StructureContainer;
+}
+
+declare const StructureContainer: StructureContainerConstructor;
+
 /**
  * Launches a nuke to another room dealing huge damage to the landing area.
  * Each launch has a cooldown and requires energy and ghodium resources. Launching
@@ -434,7 +541,7 @@ declare class StructureContainer extends Structure {
  * until it is landed. Incoming nuke cannot be moved or cancelled. Nukes cannot
  * be launched from or to novice rooms.
  */
-declare class StructureNuker extends OwnedStructure {
+interface StructureNuker extends OwnedStructure {
     /**
      * The amount of energy contained in this structure.
      */
@@ -462,12 +569,18 @@ declare class StructureNuker extends OwnedStructure {
     launchNuke(pos: RoomPosition): number;
 }
 
+interface StructureNukerConstructor {
+    new (id: string): StructureNuker;
+}
+
+declare const StructureNuker: StructureNukerConstructor;
+
 /**
  * A non-player structure. 
  * Instantly teleports your creeps to a distant room acting as a room exit tile. 
  * Portals appear randomly in the central room of each sector.
  */
-declare class StructurePortal extends Structure {
+interface StructurePortal extends Structure {
     /**
      * The position object in the destination room.
      */
@@ -477,3 +590,9 @@ declare class StructurePortal extends Structure {
      */
     ticksToDecay: number;
 }
+
+interface StructurePortalConstructor {
+    new (id: string): StructurePortal;
+}
+
+declare const StructurePortal: StructurePortalConstructor;

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -3,6 +3,8 @@
  */
 
 interface Structure extends RoomObject {
+    readonly prototype: Structure;
+
     /**
      * The current amount of hit points of the structure.
      */
@@ -34,8 +36,7 @@ interface Structure extends RoomObject {
     notifyWhenAttacked(enabled: boolean): number;
 }
 
-interface StructureConstructor {
-    new (id: string): Structure;
+interface StructureConstructor extends _Constructor<Structure>, _ConstructorById<Structure> {
 }
 
 declare const Structure: StructureConstructor;
@@ -45,6 +46,8 @@ declare const Structure: StructureConstructor;
  * found using `FIND_MY_STRUCTURES` and `FIND_HOSTILE_STRUCTURES` constants.
  */
 interface OwnedStructure extends Structure {
+    readonly prototype: OwnedStructure;
+
     /**
      * Whether this is your own structure. Walls and roads don't have this property as they are considered neutral structures.
      */
@@ -56,8 +59,7 @@ interface OwnedStructure extends Structure {
 
 }
 
-interface OwnedStructureConstructor {
-    new (id: string): OwnedStructure;
+interface OwnedStructureConstructor extends _Constructor<OwnedStructure>, _ConstructorById<OwnedStructure> {
 }
 
 declare const OwnedStructure: OwnedStructureConstructor;
@@ -68,6 +70,8 @@ declare const OwnedStructure: OwnedStructureConstructor;
  * property.
  */
 interface StructureController extends OwnedStructure {
+    readonly prototype: StructureController;
+
     /**
      * Current controller level, from 0 to 8.
      */
@@ -98,8 +102,7 @@ interface StructureController extends OwnedStructure {
     unclaim(): number;
 }
 
-interface StructureControllerConstructor {
-    new (id: string): StructureController;
+interface StructureControllerConstructor extends _Constructor<StructureController>, _ConstructorById<StructureController> {
 }
 
 declare const StructureController: StructureControllerConstructor;
@@ -110,6 +113,8 @@ declare const StructureController: StructureControllerConstructor;
  * of distance.
  */
 interface StructureExtension extends OwnedStructure {
+    readonly prototype: StructureExtension;
+
     /**
      * The amount of energy containing in the extension.
      */
@@ -126,8 +131,7 @@ interface StructureExtension extends OwnedStructure {
     transferEnergy(target: Creep, amount?: number): number;
 }
 
-interface StructureExtensionConstructor {
-    new (id: string): StructureExtension;
+interface StructureExtensionConstructor extends _Constructor<StructureExtension>, _ConstructorById<StructureExtension> {
 }
 
 declare const StructureExtension: StructureExtensionConstructor;
@@ -136,6 +140,8 @@ declare const StructureExtension: StructureExtensionConstructor;
  * Remotely transfers energy to another Link in the same room.
  */
 interface StructureLink extends OwnedStructure {
+    readonly prototype: StructureLink;
+
     /**
      * The amount of game ticks the link has to wait until the next transfer is possible.
      */
@@ -156,8 +162,7 @@ interface StructureLink extends OwnedStructure {
     transferEnergy(target: Creep | StructureLink, amount?: number): number;
 }
 
-interface StructureLinkConstructor {
-    new (id: string): StructureLink;
+interface StructureLinkConstructor extends _Constructor<StructureLink>, _ConstructorById<StructureLink> {
 }
 
 declare const StructureLink: StructureLinkConstructor;
@@ -167,14 +172,15 @@ declare const StructureLink: StructureLinkConstructor;
  * and minerals in some rooms. This structure cannot be destroyed.
  */
 interface StructureKeeperLair extends OwnedStructure {
+    readonly prototype: StructureKeeperLair;
+
     /**
      * Time to spawning of the next Source Keeper.
      */
     ticksToSpawn: number | undefined;
 }
 
-interface StructureKeeperLairConstructor {
-    new (id: string): StructureKeeperLair;
+interface StructureKeeperLairConstructor extends _Constructor<StructureKeeperLair>, _ConstructorById<StructureKeeperLair> {
 }
 
 declare const StructureKeeperLair: StructureKeeperLairConstructor;
@@ -183,6 +189,8 @@ declare const StructureKeeperLair: StructureKeeperLairConstructor;
  * Provides visibility into a distant room from your script.
  */
 interface StructureObserver extends OwnedStructure {
+    readonly prototype: StructureObserver;
+
     /**
      * Provide visibility into a distant room from your script. The target room object will be available on the next tick. The maximum range is 5 rooms.
      * @param roomName
@@ -190,8 +198,7 @@ interface StructureObserver extends OwnedStructure {
     observeRoom(roomName: string): number;
 }
 
-interface StructureObserverConstructor {
-    new (id: string): StructureObserver;
+interface StructureObserverConstructor extends _Constructor<StructureObserver>, _ConstructorById<StructureObserver> {
 }
 
 declare const StructureObserver: StructureObserverConstructor;
@@ -200,6 +207,8 @@ declare const StructureObserver: StructureObserverConstructor;
  *
  */
 interface StructurePowerBank extends OwnedStructure {
+    readonly prototype: StructurePowerBank;
+
     /**
      * The amount of power containing.
      */
@@ -210,8 +219,7 @@ interface StructurePowerBank extends OwnedStructure {
     ticksToDecay: number;
 }
 
-interface StructurePowerBankConstructor {
-    new (id: string): StructurePowerBank;
+interface StructurePowerBankConstructor extends _Constructor<StructurePowerBank>, _ConstructorById<StructurePowerBank> {
 }
 
 declare const StructurePowerBank: StructurePowerBankConstructor;
@@ -221,6 +229,7 @@ declare const StructurePowerBank: StructurePowerBankConstructor;
  * destroying the structure. Hits the attacker creep back on each attack.
  */
 interface StructurePowerSpawn extends OwnedStructure {
+    readonly prototype: StructurePowerSpawn;
     /**
      * The amount of energy containing in this structure.
      */
@@ -256,8 +265,7 @@ interface StructurePowerSpawn extends OwnedStructure {
 
 }
 
-interface StructurePowerSpawnConstructor {
-    new (id: string): StructurePowerSpawn;
+interface StructurePowerSpawnConstructor extends _Constructor<StructurePowerSpawn>, _ConstructorById<StructurePowerSpawn> {
 }
 
 declare const StructurePowerSpawn: StructurePowerSpawnConstructor;
@@ -267,6 +275,8 @@ declare const StructurePowerSpawn: StructurePowerSpawnConstructor;
  * the same tile. Can be used as a controllable gate.
  */
 interface StructureRampart extends OwnedStructure {
+    readonly prototype: StructureRampart;
+
     /**
      * The amount of game ticks when this rampart will lose some hit points.
      */
@@ -284,8 +294,7 @@ interface StructureRampart extends OwnedStructure {
     setPublic(isPublic: boolean);
 }
 
-interface StructureRampartConstructor {
-    new (id: string): StructureRampart;
+interface StructureRampartConstructor extends _Constructor<StructureRampart>, _ConstructorById<StructureRampart> {
 }
 
 declare const StructureRampart: StructureRampartConstructor;
@@ -295,14 +304,15 @@ declare const StructureRampart: StructureRampartConstructor;
  * `MOVE` body parts.
  */
 interface StructureRoad extends Structure {
+    readonly prototype: StructureRoad;
+
     /**
      * The amount of game ticks when this road will lose some hit points.
      */
     ticksToDecay: number;
 }
 
-interface StructureRoadConstructor {
-    new (id: string): StructureRoad;
+interface StructureRoadConstructor extends _Constructor<StructureRoad>, _ConstructorById<StructureRoad> {
 }
 
 declare const StructureRoad: StructureRoadConstructor;
@@ -312,6 +322,7 @@ declare const StructureRoad: StructureRoadConstructor;
  * per room is allowed that can be addressed by `Room.storage` property.
  */
 interface StructureStorage extends OwnedStructure {
+    readonly prototype: StructureStorage;
 
     /**
      * An object with the storage contents.
@@ -338,8 +349,7 @@ interface StructureStorage extends OwnedStructure {
     transferEnergy(target: Creep, amount?: number): number;
 }
 
-interface StructureStorageConstructor {
-    new (id: string): StructureStorage;
+interface StructureStorageConstructor extends _Constructor<StructureStorage>, _ConstructorById<StructureStorage> {
 }
 
 declare const StructureStorage: StructureStorageConstructor;
@@ -350,6 +360,8 @@ declare const StructureStorage: StructureStorageConstructor;
  * distance. Each action consumes energy.
  */
 interface StructureTower extends OwnedStructure {
+    readonly prototype: StructureTower;
+
     /**
      * The amount of energy containing in this structure.
      */
@@ -382,8 +394,7 @@ interface StructureTower extends OwnedStructure {
     transferEnergy(target: Creep, amount?: number): number;
 }
 
-interface StructureTowerConstructor {
-    new (id: string): StructureTower;
+interface StructureTowerConstructor extends _Constructor<StructureTower>, _ConstructorById<StructureTower> {
 }
 
 declare const StructureTower: StructureTowerConstructor;
@@ -392,14 +403,14 @@ declare const StructureTower: StructureTowerConstructor;
  * Blocks movement of all creeps.
  */
 interface StructureWall extends Structure {
+    readonly prototype: StructureWall;
     /**
      * The amount of game ticks when the wall will disappear (only for automatically placed border walls at the start of the game).
      */
     ticksToLive: number;
 }
 
-interface StructureWallConstructor {
-    new (id: string): StructureWall;
+interface StructureWallConstructor extends _Constructor<StructureWall>, _ConstructorById<StructureWall> {
 }
 
 declare const StructureWall: StructureWallConstructor;
@@ -408,10 +419,10 @@ declare const StructureWall: StructureWallConstructor;
  * Allows to harvest mineral deposits.
  */
 interface StructureExtractor extends OwnedStructure {
+    readonly prototype: StructureExtractor;
 }
 
-interface StructureExtractorConstructor {
-    new (id: string): StructureExtractor;
+interface StructureExtractorConstructor extends _Constructor<StructureExtractor>, _ConstructorById<StructureExtractor> {
 }
 
 declare const StructureExtractor: StructureExtractorConstructor;
@@ -420,6 +431,7 @@ declare const StructureExtractor: StructureExtractorConstructor;
  * Produces mineral compounds from base minerals and boosts creeps.
  */
 interface StructureLab extends OwnedStructure {
+    readonly prototype: StructureLab;
     /**
      * The amount of game ticks the lab has to wait until the next reaction is possible.
      */
@@ -465,8 +477,7 @@ interface StructureLab extends OwnedStructure {
     transfer(target: Creep, resourceType: string, amount?: number): number;
 }
 
-interface StructureLabConstructor {
-    new (id: string): StructureLab;
+interface StructureLabConstructor extends _Constructor<StructureLab>, _ConstructorById<StructureLab> {
 }
 
 declare const StructureLab: StructureLabConstructor;
@@ -475,6 +486,7 @@ declare const StructureLab: StructureLabConstructor;
  * Sends any resources to a Terminal in another room.
  */
 interface StructureTerminal extends OwnedStructure {
+    readonly prototype: StructureTerminal;
     /**
      * An object with the storage contents. Each object key is one of the RESOURCE_* constants, values are resources amounts.
      */
@@ -500,8 +512,7 @@ interface StructureTerminal extends OwnedStructure {
     transfer(target: Creep, resourceType: String, amount?: number): number;
 }
 
-interface StructureTerminalConstructor {
-    new (id: string): StructureTerminal;
+interface StructureTerminalConstructor extends _Constructor<StructureTerminal>, _ConstructorById<StructureTerminal> {
 }
 
 declare const StructureTerminal: StructureTerminalConstructor;
@@ -510,6 +521,7 @@ declare const StructureTerminal: StructureTerminalConstructor;
  * Contains up to 2,000 resource units. Can be constructed in neutral rooms. Decays for 5,000 hits per 100 ticks.
  */
 interface StructureContainer extends Structure {
+    readonly prototype: StructureContainer;
     /**
      * An object with the structure contents. Each object key is one of the RESOURCE_* constants, values are resources
      * amounts. Use _.sum(structure.store) to get the total amount of contents
@@ -528,8 +540,7 @@ interface StructureContainer extends Structure {
     transfer(target: Creep, resourceType: string, amount?: number): number;
 }
 
-interface StructureContainerConstructor {
-    new (id: string): StructureContainer;
+interface StructureContainerConstructor extends _Constructor<StructureContainer>, _ConstructorById<StructureContainer> {
 }
 
 declare const StructureContainer: StructureContainerConstructor;
@@ -542,6 +553,7 @@ declare const StructureContainer: StructureContainerConstructor;
  * be launched from or to novice rooms.
  */
 interface StructureNuker extends OwnedStructure {
+    readonly prototype: StructureNuker;
     /**
      * The amount of energy contained in this structure.
      */
@@ -569,18 +581,18 @@ interface StructureNuker extends OwnedStructure {
     launchNuke(pos: RoomPosition): number;
 }
 
-interface StructureNukerConstructor {
-    new (id: string): StructureNuker;
+interface StructureNukerConstructor extends _Constructor<StructureNuker>, _ConstructorById<StructureNuker> {
 }
 
 declare const StructureNuker: StructureNukerConstructor;
 
 /**
- * A non-player structure. 
- * Instantly teleports your creeps to a distant room acting as a room exit tile. 
+ * A non-player structure.
+ * Instantly teleports your creeps to a distant room acting as a room exit tile.
  * Portals appear randomly in the central room of each sector.
  */
 interface StructurePortal extends Structure {
+    readonly prototype: StructurePortal;
     /**
      * The position object in the destination room.
      */
@@ -591,8 +603,7 @@ interface StructurePortal extends Structure {
     ticksToDecay: number;
 }
 
-interface StructurePortalConstructor {
-    new (id: string): StructurePortal;
+interface StructurePortalConstructor extends _Constructor<StructurePortal>, _ConstructorById<StructurePortal> {
 }
 
 declare const StructurePortal: StructurePortalConstructor;

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -2,9 +2,15 @@
  * Parent object for structure classes
  */
 
+type TransferEnergyReturn = ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrNotInRange;
+
 interface Structure extends RoomObject {
     readonly prototype: Structure;
 
+    /**
+     * Room cannot be undefined for a Structure.
+     */
+    room: Room;
     /**
      * The current amount of hit points of the structure.
      */
@@ -20,11 +26,11 @@ interface Structure extends RoomObject {
     /**
      * One of the STRUCTURE_* constants.
      */
-    structureType: string;
+    structureType: StructureConst;
     /**
      * Destroy this structure immediately.
      */
-    destroy(): number;
+    destroy(): ReturnConstOk | ReturnConstErrNotOwner;
     /**
      * Check whether this structure can be used. If the room controller level is not enough, then this method will return false, and the structure will be highlighted with red in the game.
      */
@@ -33,7 +39,7 @@ interface Structure extends RoomObject {
      * Toggle auto notification when the structure is under attack. The notification will be sent to your account email. Turned on by default.
      * @param enabled Whether to enable notification or disable.
      */
-    notifyWhenAttacked(enabled: boolean): number;
+    notifyWhenAttacked(enabled: boolean): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrInvalidArgs;
 }
 
 interface StructureConstructor extends _Constructor<Structure>, _ConstructorById<Structure> {
@@ -72,6 +78,7 @@ declare const OwnedStructure: OwnedStructureConstructor;
 interface StructureController extends OwnedStructure {
     readonly prototype: StructureController;
 
+    structureType: StructureConstContainer;
     /**
      * Current controller level, from 0 to 8.
      */
@@ -87,7 +94,7 @@ interface StructureController extends OwnedStructure {
     /**
      * An object with the controller reservation info if present: username, ticksToEnd
      */
-    reservation: ReservationDefinition;
+    reservation?: ReservationDefinition;
     /**
      * The amount of game ticks when this controller will lose one level. This timer can be reset by using Creep.upgradeController.
      */
@@ -124,11 +131,13 @@ interface StructureExtension extends OwnedStructure {
      */
     energyCapacity: number;
     /**
+     * DEPRECATED: Please use Creep.withdraw instead.
      * Transfer the energy from the extension to a creep.
      * @param target The creep object which energy should be transferred to.
      * @param amount The amount of energy to be transferred. If omitted, all the remaining amount of energy will be used.
+     * @deprecated
      */
-    transferEnergy(target: Creep, amount?: number): number;
+    transferEnergy(target: Creep, amount?: number): TransferEnergyReturn;
 }
 
 interface StructureExtensionConstructor extends _Constructor<StructureExtension>, _ConstructorById<StructureExtension> {
@@ -142,6 +151,7 @@ declare const StructureExtension: StructureExtensionConstructor;
 interface StructureLink extends OwnedStructure {
     readonly prototype: StructureLink;
 
+    structureType: StructureConstLink;
     /**
      * The amount of game ticks the link has to wait until the next transfer is possible.
      */
@@ -159,7 +169,7 @@ interface StructureLink extends OwnedStructure {
      * @param target The target object.
      * @param amount The amount of energy to be transferred. If omitted, all the available energy is used.
      */
-    transferEnergy(target: Creep | StructureLink, amount?: number): number;
+    transferEnergy(target: Creep | StructureLink, amount?: number): TransferEnergyReturn | ReturnConstErrInvalidArgs | ReturnConstErrTired | ReturnConstErrRCL;
 }
 
 interface StructureLinkConstructor extends _Constructor<StructureLink>, _ConstructorById<StructureLink> {
@@ -174,6 +184,7 @@ declare const StructureLink: StructureLinkConstructor;
 interface StructureKeeperLair extends OwnedStructure {
     readonly prototype: StructureKeeperLair;
 
+    structureType: StructureConstKeeperLair;
     /**
      * Time to spawning of the next Source Keeper.
      */
@@ -191,11 +202,12 @@ declare const StructureKeeperLair: StructureKeeperLairConstructor;
 interface StructureObserver extends OwnedStructure {
     readonly prototype: StructureObserver;
 
+    structureType: StructureConstObserver;
     /**
      * Provide visibility into a distant room from your script. The target room object will be available on the next tick. The maximum range is 5 rooms.
      * @param roomName
      */
-    observeRoom(roomName: string): number;
+    observeRoom(roomName: string): ReturnConstOk | ReturnConstErrInvalidArgs | ReturnConstErrRCL;
 }
 
 interface StructureObserverConstructor extends _Constructor<StructureObserver>, _ConstructorById<StructureObserver> {
@@ -209,6 +221,7 @@ declare const StructureObserver: StructureObserverConstructor;
 interface StructurePowerBank extends OwnedStructure {
     readonly prototype: StructurePowerBank;
 
+    structureType: StructureConstPowerBank;
     /**
      * The amount of power containing.
      */
@@ -230,6 +243,8 @@ declare const StructurePowerBank: StructurePowerBankConstructor;
  */
 interface StructurePowerSpawn extends OwnedStructure {
     readonly prototype: StructurePowerSpawn;
+
+    structureType: StructureConstPowerSpawn;
     /**
      * The amount of energy containing in this structure.
      */
@@ -255,13 +270,15 @@ interface StructurePowerSpawn extends OwnedStructure {
     /**
      * Register power resource units into your account. Registered power allows to develop power creeps skills. Consumes 1 power resource unit and 50 energy resource units.
      */
-    processPower(): number;
+    processPower(): ReturnConstOk | ReturnConstErrNotEnough | ReturnConstErrRCL;
     /**
+     * DEPRECATED: Please use Creep.withdraw instead.
      * Transfer the energy from this structure to a creep.
      * @param target The creep object which energy should be transferred to.
      * @param amount The amount of energy to be transferred. If omitted, all the remaining amount of energy will be used.
+     * @deprecated
      */
-    transferEnergy(target: Creep, amount?: number): number;
+    transferEnergy(target: Creep, amount?: number): TransferEnergyReturn;
 
 }
 
@@ -277,11 +294,11 @@ declare const StructurePowerSpawn: StructurePowerSpawnConstructor;
 interface StructureRampart extends OwnedStructure {
     readonly prototype: StructureRampart;
 
+    structureType: StructureConstRampart;
     /**
      * The amount of game ticks when this rampart will lose some hit points.
      */
     ticksToDecay: number;
-
     /**
      * If false (default), only your creeps can step on the same square. If true, any hostile creeps can pass through.
      */
@@ -291,7 +308,7 @@ interface StructureRampart extends OwnedStructure {
      * Make this rampart public to allow other players' creeps to pass through.
      * @param isPublic Whether this rampart should be public or non-public
      */
-    setPublic(isPublic: boolean);
+    setPublic(isPublic: boolean): ReturnConstOk | ReturnConstErrNotOwner;
 }
 
 interface StructureRampartConstructor extends _Constructor<StructureRampart>, _ConstructorById<StructureRampart> {
@@ -306,6 +323,7 @@ declare const StructureRampart: StructureRampartConstructor;
 interface StructureRoad extends Structure {
     readonly prototype: StructureRoad;
 
+    structureType: StructureConstRoad;
     /**
      * The amount of game ticks when this road will lose some hit points.
      */
@@ -324,6 +342,7 @@ declare const StructureRoad: StructureRoadConstructor;
 interface StructureStorage extends OwnedStructure {
     readonly prototype: StructureStorage;
 
+    structureType: StructureConstStorage;
     /**
      * An object with the storage contents.
      */
@@ -334,19 +353,14 @@ interface StructureStorage extends OwnedStructure {
     storeCapacity: number;
 
     /**
+     * DEPRECATED: Please use Creep.withdraw instead.
      * Transfer resource from this storage to a creep. The target has to be at adjacent square.
      * @param target The target object.
      * @param resourceType One of the RESOURCE_* constants.
      * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
-     */
-    transfer(target: Creep, resourceType: string, amount?: number): number;
-    /**
-     * An alias for storage.transfer(target, RESOURCE_ENERGY, amount). This method is deprecated.
-     * @param target The target object.
-     * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
      * @deprecated
      */
-    transferEnergy(target: Creep, amount?: number): number;
+    transfer(target: Creep, resourceType: ResourceConst, amount?: number): TransferEnergyReturn | ReturnConstErrInvalidArgs;
 }
 
 interface StructureStorageConstructor extends _Constructor<StructureStorage>, _ConstructorById<StructureStorage> {
@@ -362,6 +376,7 @@ declare const StructureStorage: StructureStorageConstructor;
 interface StructureTower extends OwnedStructure {
     readonly prototype: StructureTower;
 
+    structureType: StructureConstTower;
     /**
      * The amount of energy containing in this structure.
      */
@@ -375,23 +390,25 @@ interface StructureTower extends OwnedStructure {
      * Remotely attack any creep in the room. Consumes 10 energy units per tick. Attack power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
      * @param target The target creep.
      */
-    attack(target: Creep): number;
+    attack(target: Creep): ReturnConstOk | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrRCL;
     /**
      * Remotely heal any creep in the room. Consumes 10 energy units per tick. Heal power depends on the distance to the target: from 400 hits at range 10 to 200 hits at range 40.
      * @param target The target creep.
      */
-    heal(target: Creep): number;
+    heal(target: Creep): ReturnConstOk | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrRCL;
     /**
      * Remotely repair any structure in the room. Consumes 10 energy units per tick. Repair power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
      * @param target The target structure.
      */
-    repair(target: Spawn | Structure): number;
+    repair(target: Structure): ReturnConstOk | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrRCL;
     /**
-     *
+     * DEPRECATED: Please use Creep.withdraw instead.
+     * Transfer the energy from this structure to a creep.
      * @param target The creep object which energy should be transferred to.
      * @param amount The amount of energy to be transferred. If omitted, all the remaining amount of energy will be used.
+     * @deprecated
      */
-    transferEnergy(target: Creep, amount?: number): number;
+    transferEnergy(target: Creep, amount?: number): TransferEnergyReturn;
 }
 
 interface StructureTowerConstructor extends _Constructor<StructureTower>, _ConstructorById<StructureTower> {
@@ -404,6 +421,8 @@ declare const StructureTower: StructureTowerConstructor;
  */
 interface StructureWall extends Structure {
     readonly prototype: StructureWall;
+
+    structureType: StructureConstWall;
     /**
      * The amount of game ticks when the wall will disappear (only for automatically placed border walls at the start of the game).
      */
@@ -420,6 +439,8 @@ declare const StructureWall: StructureWallConstructor;
  */
 interface StructureExtractor extends OwnedStructure {
     readonly prototype: StructureExtractor;
+
+    structureType: StructureConstExtractor;
 }
 
 interface StructureExtractorConstructor extends _Constructor<StructureExtractor>, _ConstructorById<StructureExtractor> {
@@ -432,6 +453,8 @@ declare const StructureExtractor: StructureExtractorConstructor;
  */
 interface StructureLab extends OwnedStructure {
     readonly prototype: StructureLab;
+
+    structureType: StructureConstLab;
     /**
      * The amount of game ticks the lab has to wait until the next reaction is possible.
      */
@@ -451,7 +474,7 @@ interface StructureLab extends OwnedStructure {
     /**
      * The type of minerals containing in the lab. Labs can contain only one mineral type at the same time.
      */
-    mineralType: string;
+    mineralType: ResourceConst;
     /**
      * The total amount of minerals the lab can contain.
      */
@@ -461,20 +484,22 @@ interface StructureLab extends OwnedStructure {
      * @param creep The target creep.
      * @param bodyPartsCount The number of body parts of the corresponding type to be boosted. Body parts are always counted left-to-right for TOUGH, and right-to-left for other types. If undefined, all the eligible body parts are boosted.
      */
-    boostCreep(creep: Creep, bodyPartsCount?: number): number;
+    boostCreep(creep: Creep, bodyPartsCount?: number): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrNotFound | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrNotInRange;
     /**
      * Produce mineral compounds using reagents from two another labs. Each lab has to be within 2 squares range. The same input labs can be used by many output labs
      * @param lab1 The first source lab.
      * @param lab2 The second source lab.
      */
-    runReaction(lab1: StructureLab, lab2: StructureLab): number;
+    runReaction(lab1: StructureLab, lab2: StructureLab): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrNotInRange | ReturnConstErrInvalidArgs | ReturnConstErrTired;
     /**
+     * DEPRECATED: Please use Creep.withdraw instead.
      * Transfer resource from this structure to a creep. The target has to be at adjacent square.
      * @param target The target object.
      * @param resourceType One of the RESOURCE_* constants.
      * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
+     * @deprecated
      */
-    transfer(target: Creep, resourceType: string, amount?: number): number;
+    transfer(target: Creep, resourceType: ResourceConst, amount?: number): TransferEnergyReturn | ReturnConstErrInvalidArgs;
 }
 
 interface StructureLabConstructor extends _Constructor<StructureLab>, _ConstructorById<StructureLab> {
@@ -487,10 +512,12 @@ declare const StructureLab: StructureLabConstructor;
  */
 interface StructureTerminal extends OwnedStructure {
     readonly prototype: StructureTerminal;
+
+    structureType: StructureConstTerminal;
     /**
      * An object with the storage contents. Each object key is one of the RESOURCE_* constants, values are resources amounts.
      */
-    store: any;
+    store: StoreDefinition;
     /**
      * The total amount of resources the storage can contain.
      */
@@ -502,14 +529,16 @@ interface StructureTerminal extends OwnedStructure {
      * @param destination The name of the target room. You don't have to gain visibility in this room.
      * @param description The description of the transaction. It is visible to the recipient. The maximum length is 100 characters.
      */
-    send(resourceType: string, amount: number, destination: string, description?: string): number;
+    send(resourceType: ResourceConst, amount: number, destination: string, description?: string): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrNotEnough | ReturnConstErrInvalidArgs;
     /**
+     * DEPRECATED: Please use Creep.withdraw instead.
      * Transfer resource from this terminal to a creep. The target has to be at adjacent square.
      * @param target The target object.
      * @param resourceType One of the RESOURCE_* constants.
      * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
+     * @deprecated
      */
-    transfer(target: Creep, resourceType: String, amount?: number): number;
+    transfer(target: Creep, resourceType: ResourceConst, amount?: number): TransferEnergyReturn | ReturnConstErrInvalidArgs;
 }
 
 interface StructureTerminalConstructor extends _Constructor<StructureTerminal>, _ConstructorById<StructureTerminal> {
@@ -522,22 +551,26 @@ declare const StructureTerminal: StructureTerminalConstructor;
  */
 interface StructureContainer extends Structure {
     readonly prototype: StructureContainer;
+
+    structureType: StructureConstContainer;
     /**
      * An object with the structure contents. Each object key is one of the RESOURCE_* constants, values are resources
      * amounts. Use _.sum(structure.store) to get the total amount of contents
      */
-    store: any;
+    store: StoreDefinition;
     /**
      * The total amount of resources the structure can contain.
      */
     storeCapacity: number;
     /**
+     * DEPRECATED: Please use Creep.withdraw instead.
      * Transfer resource from this structure to a creep. The target has to be at adjacent square.
      * @param target The target object.
      * @param resourceType One of the RESOURCE_* constants.
      * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
+     * @deprecated
      */
-    transfer(target: Creep, resourceType: string, amount?: number): number;
+    transfer(target: Creep, resourceType: ResourceConst, amount?: number): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrFull | ReturnConstErrNotInRange | ReturnConstErrInvalidArgs;
 }
 
 interface StructureContainerConstructor extends _Constructor<StructureContainer>, _ConstructorById<StructureContainer> {
@@ -554,6 +587,8 @@ declare const StructureContainer: StructureContainerConstructor;
  */
 interface StructureNuker extends OwnedStructure {
     readonly prototype: StructureNuker;
+
+    structureType: StructureConstNuker;
     /**
      * The amount of energy contained in this structure.
      */
@@ -578,7 +613,7 @@ interface StructureNuker extends OwnedStructure {
      * Launch a nuke to the specified position.
      * @param pos The target room position.
      */
-    launchNuke(pos: RoomPosition): number;
+    launchNuke(pos: RoomPosition): ReturnConstOk | ReturnConstErrNotOwner | ReturnConstErrNotEnough | ReturnConstErrInvalidTarget | ReturnConstErrNotInRange | ReturnConstErrTired | ReturnConstErrRCL;
 }
 
 interface StructureNukerConstructor extends _Constructor<StructureNuker>, _ConstructorById<StructureNuker> {
@@ -593,6 +628,8 @@ declare const StructureNuker: StructureNukerConstructor;
  */
 interface StructurePortal extends Structure {
     readonly prototype: StructurePortal;
+
+    structureType: StructureConstPortal;
     /**
      * The position object in the destination room.
      */
@@ -600,7 +637,7 @@ interface StructurePortal extends Structure {
     /**
      * The amount of game ticks when the portal disappears, or undefined when the portal is stable.
      */
-    ticksToDecay: number;
+    ticksToDecay: number | undefined;
 }
 
 interface StructurePortalConstructor extends _Constructor<StructurePortal>, _ConstructorById<StructurePortal> {


### PR DESCRIPTION
I apologize that this is a somewhat "impure" PR in that it includes a handful of unrelated improvements. The core of what it does, however, is implement literal types (string or numeric literals) for common game constants. This allows for much finer control over what is and is not valid in certain contexts, and also allows the definitions to become a bit more self-documenting.

I've erred on the side of being overly granular - defining a type for each constant - which allows for users to make very fine-grained typing rules if they so choose. This also sets the stage for creating overloads of functions like find() and look() that automatically determine the return type signature (a feature I am really looking forward to implementing).

An alternative approach would be to instead create only "categorical" literal types, and not specify the exact values, but for the time being I think this approach is better. Feedback, as always, is welcome and appreciated.
