### PR TITLE
Fix EXTENSION_ENERGY_CAPACITY index is implicit any failure

### DIFF
--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -90,7 +90,9 @@ declare var SOURCE_ENERGY_KEEPER_CAPACITY: number;
 declare var WALL_HITS: number;
 declare var WALL_HITS_MAX: number;
 declare var EXTENSION_HITS: number;
-declare var EXTENSION_ENERGY_CAPACITY: number;
+declare var EXTENSION_ENERGY_CAPACITY: {
+    [level: number]: number;
+};
 declare var ROAD_HITS: number;
 declare var ROAD_WEAROUT: number;
 declare var ROAD_DECAY_AMOUNT: number;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -104,7 +104,7 @@ declare var WALL_HITS: number;
 declare var WALL_HITS_MAX: number;
 
 declare var EXTENSION_HITS: number;
-declare var EXTENSION_ENERGY_CAPACITY: number;
+declare var EXTENSION_ENERGY_CAPACITY: {[level: number]: number};
 
 declare var ROAD_HITS: number;
 declare var ROAD_WEAROUT: number;


### PR DESCRIPTION

Reference: 
EXTENSION_ENERGY_CAPACITY: {0: 50, 1: 50, 2: 50, 3: 50, 4: 50, 5: 50, 6: 50, 7: 100, 8: 200},
http://support.screeps.com/hc/en-us/articles/203084991-API-Reference
