### PR TITLE
Add range option to findPath opts

### DIFF
--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -906,6 +906,10 @@ interface FindPathOpts {
      * The maximum allowed rooms to search. The default (and maximum) is 16. This is only used when the new PathFinder is enabled.
      */
     maxRooms?: number;
+    /**
+     * Path to within (range) tiles of target tile. The default is to path to the tile that the target is on (0).
+     */
+    range?: number;
 }
 interface MoveToOpts extends FindPathOpts {
     /**

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -149,6 +149,11 @@ interface FindPathOpts {
      * The maximum allowed rooms to search. The default (and maximum) is 16. This is only used when the new PathFinder is enabled.
      */
     maxRooms?: number;
+
+    /**
+     * Path to within (range) tiles of target tile. The default is to path to the tile that the target is on (0).
+     */
+    range?: number;
 }
 
 interface MoveToOpts extends FindPathOpts {


### PR DESCRIPTION
This option lets you path within a certain number of tiles. Helpful for if you want to move into a room (if dest is 25,25 in the new room) or are running a build or upgradeController operation which has a range of 3.

I would be 100% OK if this isn't merged as it is an undocumented option, though it is very widely used.