### PR TITLE
store energy will always be defined

### DIFF
--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -819,7 +819,7 @@ interface SignDefinition {
 }
 interface StoreDefinition {
     [resource: string]: number | undefined;
-    energy?: number;
+    energy: number;
     power?: number;
 }
 interface LookAtResultWithPos {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -47,7 +47,7 @@ interface SignDefinition {
 }
 interface StoreDefinition {
     [resource: string]: number | undefined;
-    energy?: number;
+    energy: number;
     power?: number;
 }
 


### PR DESCRIPTION
As it says in the docs (http://docs.screeps.com/api/#StructureStorage.store) energy is always defined so does not need to be an optional property.