### PR TITLE
Making RoomVisual an interface.

### DIFF
--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -1629,14 +1629,10 @@ interface RoomPositionConstructor extends _Constructor<RoomPosition> {
     (x: number, y: number, roomName: string): RoomPosition;
 }
 declare const RoomPosition: RoomPositionConstructor;
-declare class RoomVisual {
+interface RoomVisual {
+    readonly prototype: RoomVisual;
     /** The name of the room. */
     roomName: string;
-    /**
-     * You can directly create new RoomVisual object in any room, even if it's invisible to your script.
-     * @param roomName The room name.
-     */
-    constructor(roomName: string);
     /**
      * Draw a line.
      * @param x1 The start X coordinate.
@@ -1725,6 +1721,14 @@ declare class RoomVisual {
      */
     getSize(): number;
 }
+interface RoomVisualConstructor extends _Constructor<RoomVisual>, _ConstructorById<RoomVisual> {
+    /**
+     * You can directly create new RoomVisual object in any room, even if it's invisible to your script.
+     * @param roomName The room name.
+     */
+    new (roomName: string): RoomVisual;
+}
+declare const RoomVisual: RoomVisualConstructor;
 interface LineStyle {
     width?: number;
     color?: string;

--- a/src/room-visual.ts
+++ b/src/room-visual.ts
@@ -1,12 +1,8 @@
-declare class RoomVisual {
+interface RoomVisual {
+    readonly prototype: RoomVisual;
+
     /** The name of the room. */
     roomName: string;
-
-    /**
-     * You can directly create new RoomVisual object in any room, even if it's invisible to your script.
-     * @param roomName The room name.
-     */
-    constructor(roomName: string);
 
     /**
      * Draw a line.
@@ -18,7 +14,7 @@ declare class RoomVisual {
      * @returns The RoomVisual object, for chaining.
      */
     line(x1: number, y1: number, x2: number, y2: number, style?: LineStyle): RoomVisual;
-    
+
     /**
      * Draw a line.
      * @param pos1 The start position object.
@@ -106,6 +102,15 @@ declare class RoomVisual {
      */
     getSize(): number;
 }
+
+interface RoomVisualConstructor extends _Constructor<RoomVisual>, _ConstructorById<RoomVisual> {
+    /**
+     * You can directly create new RoomVisual object in any room, even if it's invisible to your script.
+     * @param roomName The room name.
+     */
+    new(roomName: string): RoomVisual;
+}
+declare const RoomVisual: RoomVisualConstructor;
 
 interface LineStyle {
     width?: number;


### PR DESCRIPTION
I found a helpful project to help us using RoomVisual in github, which is trying to extend the RoomVisual by changing its prototype: https://github.com/screepers/RoomVisual.

To make the project work for typescript, I created a typing to extend the RoomVisual: https://github.com/r12f/screeps-room-visual-extension-typings.

But since RoomVisual is declared as a class, typescript doesn't allow us to do it, so I am thinking to change this class to an interface.

I am very new in typescript, so please let me know, if it is actually a horrible idea.