### PR TITLE
Typing of storage of Terminals and Containers

### DIFF
--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -819,7 +819,7 @@ interface SignDefinition {
 }
 interface StoreDefinition {
     [resource: string]: number | undefined;
-    energy?: number;
+    energy: number;
     power?: number;
 }
 interface LookAtResultWithPos {

--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -2499,7 +2499,7 @@ interface StructureTerminal extends OwnedStructure {
     /**
      * An object with the storage contents. Each object key is one of the RESOURCE_* constants, values are resources amounts.
      */
-    store: any;
+    store: StoreDefinition;
     /**
      * The total amount of resources the storage can contain.
      */
@@ -2532,7 +2532,7 @@ interface StructureContainer extends Structure {
      * An object with the structure contents. Each object key is one of the RESOURCE_* constants, values are resources
      * amounts. Use _.sum(structure.store) to get the total amount of contents
      */
-    store: any;
+    store: StoreDefinition;
     /**
      * The total amount of resources the structure can contain.
      */

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -47,7 +47,7 @@ interface SignDefinition {
 }
 interface StoreDefinition {
     [resource: string]: number | undefined;
-    energy?: number;
+    energy: number;
     power?: number;
 }
 

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -531,7 +531,7 @@ interface StructureTerminal extends OwnedStructure {
     /**
      * An object with the storage contents. Each object key is one of the RESOURCE_* constants, values are resources amounts.
      */
-    store: any;
+    store: StoreDefinition;
     /**
      * The total amount of resources the storage can contain.
      */
@@ -567,7 +567,7 @@ interface StructureContainer extends Structure {
      * An object with the structure contents. Each object key is one of the RESOURCE_* constants, values are resources
      * amounts. Use _.sum(structure.store) to get the total amount of contents
      */
-    store: any;
+    store: StoreDefinition;
     /**
      * The total amount of resources the structure can contain.
      */


### PR DESCRIPTION
Since we have an interface for objects that have an storage, we should use it instead of any. Also, the energy-property always is available, see official doc on Terminals/Containers/Storage.

One should probably also unify the documenting comment of the store property...