### PR TITLE
Make memory extensible

### DIFF
--- a/src/creep.ts
+++ b/src/creep.ts
@@ -42,7 +42,7 @@ interface Creep extends RoomObject {
     /**
      * A shorthand to Memory.creeps[creep.name]. You can use it for quick access the creep’s specific memory data object.
      */
-    memory: any;
+    memory: CreepMemory;
     /**
      * Whether it is your creep or foe.
      */
@@ -230,5 +230,6 @@ interface Creep extends RoomObject {
 
 interface CreepConstructor extends _Constructor<Creep>, _ConstructorById<Creep> {
 }
+interface CreepMemory { }
 
 declare const Creep: CreepConstructor;

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -11,7 +11,7 @@ interface Flag extends RoomObject {
     /**
      * A shorthand to Memory.flags[flag.name]. You can use it for quick access the flag's specific memory data object.
      */
-    memory: any;
+    memory: FlagMemory;
     /**
      * Flag’s name. You can choose the name while creating a new flag, and it cannot be changed later. This name is a hash key to access the spawn via the Game.flags object.
      */
@@ -51,5 +51,7 @@ interface FlagConstructor extends _Constructor<Flag> {
     new (name: string, color: number, secondaryColor: number, roomName: string, x: number, y: number): Flag;
     (name: string, color: number, secondaryColor: number, roomName: string, x: number, y: number): Flag;
 }
+
+interface FlagMemory { }
 
 declare const Flag: FlagConstructor;

--- a/src/room.ts
+++ b/src/room.ts
@@ -19,7 +19,7 @@ interface Room {
     /**
      * A shorthand to Memory.rooms[room.name]. You can use it for quick access the room’s specific memory data object.
      */
-    memory: any;
+    memory: RoomMemory;
     /**
      * One of the following constants:
      * MODE_SIMULATION, MODE_SURVIVAL, MODE_WORLD, MODE_ARENA
@@ -169,5 +169,7 @@ interface RoomConstructor {
     serializePath(path: PathStep[]): string;
     deserializePath(path: string): PathStep[];
 }
+
+interface RoomMemory { }
 
 declare const Room: RoomConstructor;

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -33,7 +33,7 @@ interface StructureSpawn extends OwnedStructure {
     /**
      * A shorthand to Memory.spawns[spawn.name]. You can use it for quick access the spawn’s specific memory data object.
      */
-    memory: any;
+    memory: SpawnMemory;
     /**
      * Spawn’s name. You choose the name upon creating a new spawn, and it cannot be changed later. This name is a hash key to access the spawn via the Game.spawns object.
      */
@@ -119,5 +119,7 @@ interface StructureSpawn extends OwnedStructure {
 
 interface StructureSpawnConstructor extends _Constructor<StructureSpawn>, _ConstructorById<StructureSpawn> {
 }
+
+interface SpawnMemory { }
 
 declare const StructureSpawn: StructureSpawnConstructor;


### PR DESCRIPTION
This is an updated version of #107 with just the minimal changes.

Once this PR is in, it'll be very easy to extend your object's memory in your own `index.d.ts` file like this:

```
interface Room {
  memory: RoomMemory;
}

interface RoomMemory {
  spawnerId?: string;
}
```